### PR TITLE
Fix support for ssh clones of kart repos.

### DIFF
--- a/kart/gui/dockwidget.py
+++ b/kart/gui/dockwidget.py
@@ -1,4 +1,5 @@
 import os
+import re
 import tempfile
 
 from qgis.PyQt import uic
@@ -246,9 +247,13 @@ class ReposItem(RefreshableItem):
         dialog.show()
         ret = dialog.exec_()
         if ret == dialog.Accepted:
-            repo = Repository.clone(
-                dialog.src, dialog.dst, dialog.location, dialog.extent
-            )
+
+            src = dialog.src
+            # Prefix file protocol if the protcol is otherwise unknown.
+            if not re.match(r"^(kart@|http(s)?://|file://).*", src):
+                src = f"file://{src}"
+
+            repo = Repository.clone(src, dialog.dst, dialog.location, dialog.extent)
             item = RepoItem(repo)
             self.addChild(item)
             addRepo(repo)

--- a/kart/kartapi.py
+++ b/kart/kartapi.py
@@ -290,8 +290,6 @@ class Repository:
 
     @staticmethod
     def clone(src, dst, location=None, extent=None):
-        if "://" not in src:
-            src = f"file://{src}"
         commands = ["-vv", "clone", src, dst, "--progress"]
         if location is not None:
             commands.extend(["--workingcopy", location])


### PR DESCRIPTION
The plugin currently fails to recognize SSH paths to hosted repositories.

This change moves the responsibility for determining the users intended clone source into the clone widget. This also fixes handling of paths already prefixed with `file://` and tightens up the checking of http/https paths.