### PR TITLE
Fix error when setting a spatial filter during clones

### DIFF
--- a/kart/kartapi.py
+++ b/kart/kartapi.py
@@ -296,7 +296,7 @@ class Repository:
             commands.extend(["--workingcopy", location])
         if extent is not None:
             kartExtent = f"{extent.crs().authid()};{extent.asWktPolygon()}"
-            commands.extent(["--spatial-filter", kartExtent])
+            commands.extend(["--spatial-filter", kartExtent])
 
         with progressBar("Clone") as bar:
             bar.setText("Cloning repository")


### PR DESCRIPTION
See commit, trivial fix for a typo in the command list for clone spatial extents.