### PR TITLE
Ensure user name and email aren’t blank strings on commit

### DIFF
--- a/kart/gui/userconfigdialog.py
+++ b/kart/gui/userconfigdialog.py
@@ -16,7 +16,7 @@ WIDGET, BASE = uic.loadUiType(
 
 
 class UserConfigDialog(BASE, WIDGET):
-    def __init__(self):
+    def __init__(self, existingConfigDict):
         super(QDialog, self).__init__(iface.mainWindow())
         self.setupUi(self)
 
@@ -26,6 +26,8 @@ class UserConfigDialog(BASE, WIDGET):
 
         self.buttonBox.accepted.connect(self.okClicked)
         self.buttonBox.rejected.connect(self.reject)
+        self.txtUsername.setText(existingConfigDict.get('user.name'))
+        self.txtEmail.setText(existingConfigDict.get('user.email'))
 
     def okClicked(self):
         self.username = self.txtUsername.text().strip()

--- a/kart/kartapi.py
+++ b/kart/kartapi.py
@@ -427,9 +427,9 @@ class Repository:
 
     def checkUserConfigured(self):
         configDict = self._config()
-        if "user.name" in configDict and "user.email" in configDict:
+        if all(configDict.get(configKey) for configKey in ('user.name', 'user.email')):
             return True
-        dlg = UserConfigDialog()
+        dlg = UserConfigDialog(configDict)
         if dlg.exec() == dlg.Accepted:
             self.configureUser(dlg.username, dlg.email)
             return True

--- a/kart/kartapi.py
+++ b/kart/kartapi.py
@@ -427,6 +427,7 @@ class Repository:
 
     def checkUserConfigured(self):
         configDict = self._config()
+        # check user name/email are set and non-empty
         if all(configDict.get(configKey) for configKey in ('user.name', 'user.email')):
             return True
         dlg = UserConfigDialog(configDict)


### PR DESCRIPTION
Name and email can be set from the command line git or kart client to an empty string which was passing the config check.

When showing the user config dialog enter any existing values.