### PR TITLE
Consistent swipe direction change

### DIFF
--- a/helper.py
+++ b/helper.py
@@ -114,7 +114,7 @@ if len(sys.argv) == 2 and sys.argv[1] == "install":
     install()
 elif len(sys.argv) in [2, 3] and sys.argv[1] == "package":
     package(*sys.argv[2:])
-if len(sys.argv) == 3 and sys.argv[1] == "publish":
+elif len(sys.argv) == 3 and sys.argv[1] == "publish":
     publish(sys.argv[2])
 else:
     usage()

--- a/helper.py
+++ b/helper.py
@@ -114,7 +114,7 @@ if len(sys.argv) == 2 and sys.argv[1] == "install":
     install()
 elif len(sys.argv) in [2, 3] and sys.argv[1] == "package":
     package(*sys.argv[2:])
-elif len(sys.argv) == 3 and sys.argv[1] == "publish":
+if len(sys.argv) == 3 and sys.argv[1] == "publish":
     publish(sys.argv[2])
 else:
     usage()

--- a/kart/gui/mapswipetool.py
+++ b/kart/gui/mapswipetool.py
@@ -56,6 +56,11 @@ class MapSwipeTool(QgsMapTool):
         self.canvas().setCursor(QCursor(Qt.PointingHandCursor))
 
     def canvasMoveEvent(self, e):
+        if (e.x(), e.y()) == (self.firstPoint.x(), self.firstPoint.y()):
+            # the moveEvent was fired immediately after the press event,
+            # don't change the swipe direction
+            return
+
         THRESHOLD = 10
         if self.hasSwipe:
             if self.checkDirection:


### PR DESCRIPTION
When a move event fired immediately after a press a checkDirection was done
and the isVertical check sometimes inconsistently calculated. This makes the
swipe direction always follow the mouse drag.