### PR TITLE
Renaming `changes` to `diff` for consistency

### DIFF
--- a/kart/gui/diffviewer.py
+++ b/kart/gui/diffviewer.py
@@ -74,7 +74,7 @@ WIDGET, BASE = uic.loadUiType(
 
 
 class DiffViewerDialog(QDialog):
-    def __init__(self, parent, changes, repo, showRecoverNewButton=True):
+    def __init__(self, parent, diff, repo, showRecoverNewButton=True):
         super(QDialog, self).__init__(parent)
         self.setWindowFlags(Qt.Window)
         layout = QVBoxLayout()
@@ -82,7 +82,7 @@ class DiffViewerDialog(QDialog):
         self.bar = QgsMessageBar()
         self.bar.setSizePolicy(QSizePolicy.Minimum, QSizePolicy.Fixed)
         layout.addWidget(self.bar)
-        self.history = DiffViewerWidget(changes, repo, showRecoverNewButton)
+        self.history = DiffViewerWidget(diff, repo, showRecoverNewButton)
         self.history.workingLayerChanged.connect(self.workingLayerChanged)
         layout.addWidget(self.history)
         self.setLayout(layout)
@@ -101,9 +101,9 @@ class DiffViewerWidget(WIDGET, BASE):
 
     workingLayerChanged = pyqtSignal()
 
-    def __init__(self, changes, repo, showRecoverNewButton):
+    def __init__(self, diff, repo, showRecoverNewButton):
         super(DiffViewerWidget, self).__init__()
-        self.changes = changes
+        self.diff = diff
         self.repo = repo
         self.oldLayer = None
         self.newLayer = None
@@ -302,7 +302,7 @@ class DiffViewerWidget(WIDGET, BASE):
 
     def fillTree(self):
         self.featuresTree.clear()
-        for dataset, changes in self.changes.items():
+        for dataset, changes in self.diff.items():
             if dataset not in self.workingCopyLayerCrs:
                 self.workingCopyLayerCrs[dataset] = self.repo.workingCopyLayerCrs(
                     dataset

--- a/kart/gui/dockwidget.py
+++ b/kart/gui/dockwidget.py
@@ -466,11 +466,11 @@ class RepoItem(RefreshableItem):
                 level=Qgis.Warning,
             )
             return
-        changes = self.repo.diff()
-        hasChanges = any([bool(c) for c in changes.values()])
+        diff = self.repo.diff()
+        hasChanges = any([bool(c) for c in diff.values()])
         if hasChanges:
             dialog = DiffViewerDialog(
-                iface.mainWindow(), changes, self.repo, showRecoverNewButton=False
+                iface.mainWindow(), diff, self.repo, showRecoverNewButton=False
             )
             dialog.exec()
         else:
@@ -684,7 +684,7 @@ class DatasetItem(QTreeWidgetItem):
 
     @executeskart
     def commitChanges(self):
-        changes = changes = self.repo.changes().get(self.name)
+        changes = self.repo.changes().get(self.name)
         if changes is None:
             iface.messageBar().pushMessage(
                 "Commit", "Nothing to commit", level=Qgis.Warning
@@ -713,10 +713,10 @@ class DatasetItem(QTreeWidgetItem):
                 level=Qgis.Warning,
             )
             return
-        changes = self.repo.diff(dataset=self.name)
-        if changes.get(self.name):
+        diff = self.repo.diff(dataset=self.name)
+        if diff.get(self.name):
             dialog = DiffViewerDialog(
-                iface.mainWindow(), changes, self.repo, showRecoverNewButton=False
+                iface.mainWindow(), diff, self.repo, showRecoverNewButton=False
             )
             dialog.exec()
         else:

--- a/kart/gui/historyviewer.py
+++ b/kart/gui/historyviewer.py
@@ -256,8 +256,8 @@ class HistoryTree(QTreeWidget):
                 Qgis.Warning,
             )
             return
-        changes = self.repo.diff(refa, parent)
-        dialog = DiffViewerDialog(self, changes, self.repo)
+        diff = self.repo.diff(refa, parent)
+        dialog = DiffViewerDialog(self, diff, self.repo)
         dialog.exec()
 
     @executeskart
@@ -270,8 +270,8 @@ class HistoryTree(QTreeWidget):
                 Qgis.Warning,
             )
             return
-        changes = self.repo.diff(refa, refb)
-        dialog = DiffViewerDialog(self, changes, self.repo)
+        diff = self.repo.diff(refa, refb)
+        dialog = DiffViewerDialog(self, diff, self.repo)
         dialog.exec()
 
     @executeskart
@@ -294,9 +294,9 @@ class HistoryTree(QTreeWidget):
                 Qgis.Warning,
             )
             return
-        changes = self.repo.diff(refb, refa)
-        for dataset in changes:
-            geojson = {"type": "FeatureCollection", "features": changes[dataset]}
+        diff = self.repo.diff(refb, refa)
+        for dataset in diff:
+            geojson = {"type": "FeatureCollection", "features": diff[dataset]}
             layer = QgsVectorLayer(
                 json.dumps(geojson), f"{dataset}_diff_{refa[:7]}", "ogr"
             )

--- a/kart/layers.py
+++ b/kart/layers.py
@@ -288,10 +288,10 @@ class LayerTracker:
                     level=Qgis.Warning,
                 )
                 return
-            changes = repo.diff(dataset=dataset)
-            if changes.get(dataset):
+            diff = repo.diff(dataset=dataset)
+            if diff.get(dataset):
                 dialog = DiffViewerDialog(
-                    iface.mainWindow(), changes, repo, showRecoverNewButton=False
+                    iface.mainWindow(), diff, repo, showRecoverNewButton=False
                 )
                 dialog.exec()
             else:


### PR DESCRIPTION
The output of `Repository.diff` is sometimes called called `diff`, sometimes `changes`. This gets confusing, because `Repository` also has a method called `changes`, whose output gets called `changes`. 

So I have renamed the output of `Repository.diff` from `changes` to `diff`.