### PR TITLE
Require Kart 0.11. Fix warning from --json-style option

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ $ git clone https://github.com/koordinates/kart-qgis-plugin.git
 - Create a link between the repository folder and the QGIS 3 plugins folder.
 
 ```console
-$ cd kart-qgis-plugn
+$ cd kart-qgis-plugin
 $ python helper.py install
 ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -24,7 +24,7 @@ If the installed version is not correct, you will see a message like this:
 
 ![Wrong version](img/wrongversion.png)
 
-Currently, the minimum required Kart versions is v0.10.8.
+Currently, the minimum required Kart versions is v0.11.0.
 
 ## Creating a repository
 

--- a/kart/kartapi.py
+++ b/kart/kartapi.py
@@ -35,7 +35,7 @@ from kart.gui.installationwarningdialog import InstallationWarningDialog
 from kart.utils import progressBar, setting, setSetting, KARTPATH
 from kart import logging
 
-SUPPORTED_VERSION = "0.10.8"
+SUPPORTED_VERSION = "0.11.0"
 
 
 class KartException(Exception):
@@ -590,7 +590,7 @@ class Repository:
     def diff(self, refa=None, refb=None, dataset=None, featureid=None):
         changes = {}
         try:
-            commands = ["diff", "-ogeojson", "--json-style", "extracompact"]
+            commands = ["diff", "-ogeojson:extracompact"]
             if refa and refb:
                 commands.append(f"{refb}...{refa}")
             elif refa:
@@ -657,7 +657,7 @@ class Repository:
         return False
 
     def conflicts(self):
-        commands = ["conflicts", "-ogeojson", "--json-style", "extracompact"]
+        commands = ["conflicts", "-ogeojson:extracompact"]
         features = json.loads(self.executeKart(commands)).get("features", [])
         conflicts = {}
         for feature in features:

--- a/kart/kartapi.py
+++ b/kart/kartapi.py
@@ -590,7 +590,7 @@ class Repository:
     def diff(self, refa=None, refb=None, dataset=None, featureid=None):
         changes = {}
         try:
-            commands = ["diff", "-ogeojson:extracompact"]
+            commands = ["diff", "--output-format=geojson:extracompact"]
             if refa and refb:
                 commands.append(f"{refb}...{refa}")
             elif refa:
@@ -657,7 +657,7 @@ class Repository:
         return False
 
     def conflicts(self):
-        commands = ["conflicts", "-ogeojson:extracompact"]
+        commands = ["conflicts", "--output-format=geojson:extracompact"]
         features = json.loads(self.executeKart(commands)).get("features", [])
         conflicts = {}
         for feature in features:


### PR DESCRIPTION
Kart's --json-style option was deprecated in Kart 0.11.0.

This change means that the plugin now requires at least Kart 0.11.0