### PR TITLE
Support kart helper mode

### DIFF
--- a/kart/gui/settingsdialog.py
+++ b/kart/gui/settingsdialog.py
@@ -6,7 +6,7 @@ from qgis.gui import QgsMessageBar
 from qgis.PyQt import uic
 from qgis.PyQt.QtWidgets import QDialog, QSizePolicy, QFileDialog
 
-from kart.utils import setting, setSetting, KARTPATH, AUTOCOMMIT, DIFFSTYLES
+from kart.utils import setting, setSetting, KARTPATH, HELPERMODE, AUTOCOMMIT, DIFFSTYLES
 
 WIDGET, BASE = uic.loadUiType(
     os.path.join(os.path.dirname(__file__), "settingsdialog.ui")
@@ -35,6 +35,7 @@ class SettingsDialog(BASE, WIDGET):
 
     def setValues(self):
         self.comboDiffStyles.setCurrentText(setting(DIFFSTYLES))
+        self.chkHelperMode.setChecked(setting(HELPERMODE))
         self.chkAutoCommit.setChecked(setting(AUTOCOMMIT))
         self.txtKartPath.setText(setting(KARTPATH))
 
@@ -47,6 +48,7 @@ class SettingsDialog(BASE, WIDGET):
 
     def okClicked(self):
         setSetting(KARTPATH, self.txtKartPath.text())
+        setSetting(HELPERMODE, self.chkHelperMode.isChecked())
         setSetting(AUTOCOMMIT, self.chkAutoCommit.isChecked())
         setSetting(DIFFSTYLES, self.comboDiffStyles.currentText())
         self.accept()

--- a/kart/gui/settingsdialog.ui
+++ b/kart/gui/settingsdialog.ui
@@ -19,27 +19,39 @@
      <property name="title">
       <string>Kart executable</string>
      </property>
-     <layout class="QHBoxLayout" name="horizontalLayout_2">
+
+     <layout class="QVBoxLayout" name="verticalLayout1">
       <item>
-       <widget class="QLabel" name="label_2">
-        <property name="text">
-         <string>Path to Kart executable</string>
-        </property>
-       </widget>
+        <layout class="QHBoxLayout" name="horizontalLayout_2">
+          <item>
+          <widget class="QLabel" name="label_2">
+            <property name="text">
+            <string>Path to Kart executable</string>
+            </property>
+          </widget>
+          </item>
+          <item>
+          <widget class="QLineEdit" name="txtKartPath">
+            <property name="placeholderText">
+            <string>[Leave empty to use default Kart installation path]</string>
+            </property>
+          </widget>
+          </item>
+          <item>
+          <widget class="QToolButton" name="btnBrowsePath">
+            <property name="text">
+            <string>...</string>
+            </property>
+          </widget>
+          </item>
+        </layout>
       </item>
       <item>
-       <widget class="QLineEdit" name="txtKartPath">
-        <property name="placeholderText">
-         <string>[Leave empty to use default Kart installation path]</string>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QToolButton" name="btnBrowsePath">
-        <property name="text">
-         <string>...</string>
-        </property>
-       </widget>
+        <widget class="QCheckBox" name="chkHelperMode">
+          <property name="text">
+          <string>Use helper mode</string>
+          </property>
+        </widget>
       </item>
      </layout>
     </widget>

--- a/kart/kartapi.py
+++ b/kart/kartapi.py
@@ -32,7 +32,7 @@ from qgis.utils import iface
 from kart.gui.userconfigdialog import UserConfigDialog
 from kart.gui.installationwarningdialog import InstallationWarningDialog
 
-from kart.utils import progressBar, setting, setSetting, KARTPATH
+from kart.utils import progressBar, setting, setSetting, KARTPATH, HELPERMODE
 from kart import logging
 
 SUPPORTED_VERSION = "0.10.8"
@@ -200,8 +200,8 @@ def executeKart(commands, path=None, jsonoutput=False, feedback=None):
         if "PYTHONHOME" in executeKart.env:
             executeKart.env.pop("PYTHONHOME")
 
-    # run in kart in helper mode if available
-    executeKart.env['KART_USE_HELPER'] = '1'
+    # always set the use helper env var as it is long lived and the setting may have changed
+    executeKart.env['KART_USE_HELPER'] = '1' if setting(HELPERMODE) else ''
 
     try:
         encoding = locale.getdefaultlocale()[1] or "utf-8"

--- a/kart/kartapi.py
+++ b/kart/kartapi.py
@@ -87,7 +87,7 @@ def kartExecutable():
     else:
         defaultFolder = "/opt/kart"
     folder = setting(KARTPATH) or defaultFolder
-    for exe_name in ("kart.exe", "kart_cli", "kart"):
+    for exe_name in ("kart.exe", "kart_cli_helper", "kart_cli", "kart"):
         path = os.path.join(folder, exe_name)
         if os.path.isfile(path):
             return path

--- a/kart/tests/test_kartapi.py
+++ b/kart/tests/test_kartapi.py
@@ -61,12 +61,12 @@ class TestKartapi(unittest.TestCase):
 
     def testEnableUseHelper(self):
         setSetting(HELPERMODE, True)
-        ret = kartVersionDetails()  # called to set up environment var
+        kartVersionDetails()  # called to set up environment var
         assert executeKart.env['KART_USE_HELPER'] == '1', "Helper mode was not enabled"
 
     def testChangeHelperMode(self):
         """
-        KART_USE_HELPER should be set each time executeKart is called so 
+        KART_USE_HELPER should be set each time executeKart is called so
         a change of setting is applied appropriately
         """
         setSetting(HELPERMODE, True)
@@ -74,7 +74,6 @@ class TestKartapi(unittest.TestCase):
         setSetting(HELPERMODE, False)
         kartVersionDetails()  # called to set up environment var
         assert executeKart.env['KART_USE_HELPER'] == '', "Helper mode was not disabled"
-
 
     def testKartVersion(self):
         version = installedVersion()

--- a/kart/tests/test_kartapi.py
+++ b/kart/tests/test_kartapi.py
@@ -70,9 +70,9 @@ class TestKartapi(unittest.TestCase):
         a change of setting is applied appropriately
         """
         setSetting(HELPERMODE, True)
-        ret = kartVersionDetails()  # called to set up environment var
+        kartVersionDetails()  # called to set up environment var
         setSetting(HELPERMODE, False)
-        ret = kartVersionDetails()  # called to set up environment var
+        kartVersionDetails()  # called to set up environment var
         assert executeKart.env['KART_USE_HELPER'] == '', "Helper mode was not disabled"
 
 

--- a/kart/tests/test_kartapi.py
+++ b/kart/tests/test_kartapi.py
@@ -20,8 +20,9 @@ from kart.kartapi import (
     Repository,
     readReposFromSettings,
     installedVersion,
+    executeKart,
 )
-from kart.utils import setSetting, KARTPATH
+from kart.utils import HELPERMODE, setSetting, KARTPATH
 from kart.tests.utils import patch_iface
 
 start_app()
@@ -57,6 +58,23 @@ class TestKartapi(unittest.TestCase):
         setSetting(KARTPATH, "wrongpath")
         ret = kartVersionDetails()
         assert "Kart is not correctly configured" in ret
+
+    def testEnableUseHelper(self):
+        setSetting(HELPERMODE, True)
+        ret = kartVersionDetails()  # called to set up environment var
+        assert executeKart.env['KART_USE_HELPER'] == '1', "Helper mode was not enabled"
+
+    def testChangeHelperMode(self):
+        """
+        KART_USE_HELPER should be set each time executeKart is called so 
+        a change of setting is applied appropriately
+        """
+        setSetting(HELPERMODE, True)
+        ret = kartVersionDetails()  # called to set up environment var
+        setSetting(HELPERMODE, False)
+        ret = kartVersionDetails()  # called to set up environment var
+        assert executeKart.env['KART_USE_HELPER'] == '', "Helper mode was not disabled"
+
 
     def testKartVersion(self):
         version = installedVersion()

--- a/kart/utils.py
+++ b/kart/utils.py
@@ -80,11 +80,12 @@ def layerFromSource(path):
 
 NAMESPACE = "kart"
 KARTPATH = "KartPath"
+HELPERMODE = "HelperMode"
 AUTOCOMMIT = "AutoCommit"
 DIFFSTYLES = "DiffStyles"
 LASTREPO = "LastRepo"
 
-setting_types = {AUTOCOMMIT: bool}
+setting_types = {HELPERMODE: bool, AUTOCOMMIT: bool}
 
 
 def setSetting(name, value):


### PR DESCRIPTION
kart v0.11.5 + supports helper mode to speed up commands. This puts in place a setting to optionally enable this helper mode.

- bool option on the settings dialog
- set KART_USE_HELPER = 1 when setting enabled
- add kart_cli_helper in executable search order so that helper mode can be used