### PR TITLE
Handle errors in kart when 'feedback' is required

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        qgis_version: [release-3_16, latest]
+        qgis_version: [release-3_16, 'release-3_22', latest]
       fail-fast: false
 
     env:

--- a/kart/kartapi.py
+++ b/kart/kartapi.py
@@ -57,7 +57,7 @@ def executeskart(f):
             lines = str(ex).splitlines()
             msglines = []
             for line in lines:
-                if line.startswith("ERROR 1: Can't load"):
+                if line.startswith("ERROR 1: Can't load") or '.dylib' in line:
                     continue
                 if "The specified procedure could not be found" in line:
                     continue
@@ -201,7 +201,7 @@ def executeKart(commands, path=None, jsonoutput=False, feedback=None):
             executeKart.env.pop("PYTHONHOME")
 
     # run in kart in helper mode if available
-    executeKart.env['KART_USE_HELPER'] = '1'
+    executeKart.env["KART_USE_HELPER"] = "1"
 
     try:
         encoding = locale.getdefaultlocale()[1] or "utf-8"
@@ -229,11 +229,12 @@ def executeKart(commands, path=None, jsonoutput=False, feedback=None):
                     output.append(line)
                 stdout = "".join(output)
                 stderr = "".join(err)
+                proc.communicate()  # need to get the returncode
             else:
                 stdout, stderr = proc.communicate()
             logging.debug(f"Command output: {stdout}")
             if proc.returncode:
-                raise Exception(stderr)
+                raise KartException(stderr)
             if jsonoutput:
                 return json.loads(stdout)
             else:

--- a/kart/kartapi.py
+++ b/kart/kartapi.py
@@ -57,6 +57,7 @@ def executeskart(f):
             lines = str(ex).splitlines()
             msglines = []
             for line in lines:
+                # skip lines that refer to missing loads of shared libraries
                 if line.startswith("ERROR 1: Can't load") or '.dylib' in line:
                     continue
                 if "The specified procedure could not be found" in line:
@@ -207,7 +208,9 @@ def executeKart(commands, path=None, jsonoutput=False, feedback=None):
         encoding = locale.getdefaultlocale()[1] or "utf-8"
         QApplication.setOverrideCursor(Qt.WaitCursor)
         logging.debug(f"Command: {' '.join(commands)}")
-
+        # TODO - all of this should be replaced by useage of QgsTask which
+        #  will execute on a background thread. There are a number of
+        #  ways in which this can deadlock
         with subprocess.Popen(
             commands,
             shell=os.name == "nt",

--- a/kart/tests/test_kartapi.py
+++ b/kart/tests/test_kartapi.py
@@ -20,6 +20,7 @@ from kart.kartapi import (
     Repository,
     readReposFromSettings,
     installedVersion,
+    KartException,
 )
 from kart.utils import setSetting, KARTPATH
 from kart.tests.utils import patch_iface
@@ -271,3 +272,12 @@ class TestKartapi(unittest.TestCase):
         repo.deleteTag("mytag")
         assert repo.tags() == []
         folder.cleanup()
+
+    def testCloneAuthFailed(self):
+        with tempfile.TemporaryDirectory() as folder:
+            with self.assertRaises(KartException):
+                Repository.clone(
+                    "https://kart:abcdefghijklmnop@data.koordinates.com/"
+                    "land-information-new-zealand/layer-50804",
+                    folder,
+                )


### PR DESCRIPTION
When 'feedback' is required for progress bar display the returncode wasn't being set on executeKart and so errors were not being raise to the calling code. An example of this is a 'clone' which failed due to permissions errors which would also cascade to errors around a repo being created in the repositories panel which was invalid.

Also reduce noise in the error dialog so that on MacOS dylib errors in the result aren't displayed in the dialog.

Add LTR (3.22) to text matrix.