### PR TITLE
Fix kart log invocation for kart 0.12

### DIFF
--- a/kart/kartapi.py
+++ b/kart/kartapi.py
@@ -469,7 +469,7 @@ class Repository:
             else:
                 filt = dataset
 
-            commands = ["log", "-ojson", ref, "--", "--", filt]
+            commands = ["log", "-ojson", ref, "--", filt]
         else:
             commands = ["log", "-ojson", ref]
         ret = self.executeKart(commands)
@@ -480,13 +480,12 @@ class Repository:
                 "log",
                 ref,
                 "--graph",
-                "--format=format:%H%n ",
-                "--",
+                "-otext:%H%n",
                 "--",
                 filt,
             ]
         else:
-            commands = ["log", ref, "--graph", "--format=format:%H%n "]
+            commands = ["log", ref, "--graph", "-otext:%H%n"]
         logb = self.executeKart(commands)
         lines = logb.splitlines()
         lines.insert(0, "")

--- a/kart/kartapi.py
+++ b/kart/kartapi.py
@@ -35,7 +35,7 @@ from kart.gui.installationwarningdialog import InstallationWarningDialog
 from kart.utils import progressBar, setting, setSetting, KARTPATH, HELPERMODE
 from kart import logging
 
-SUPPORTED_VERSION = "0.11.5"
+SUPPORTED_VERSION = "0.12.1"
 
 
 class KartException(Exception):


### PR DESCRIPTION
As of Kart 0.12, kart log drops support for unrecognised Git log options, although it still uses Git log internally. Many Git log options are still recognised as kart log options, or there is a similar kart log option.

The fix here is to use `-otext:FORMAT` instead of `--format=FORMAT`. The double-double-dashes are no longer required.

See https://github.com/koordinates/kart-qgis-plugin/issues/92