### PR TITLE
create repo: fix error adding repo after creation

### DIFF
--- a/kart/gui/dockwidget.py
+++ b/kart/gui/dockwidget.py
@@ -248,7 +248,7 @@ class ReposItem(RefreshableItem):
             repo = Repository(dialog.folder)
             repo.init(dialog.location)
             if repo.isInitialized():
-                RepoManager.add_repo(repo)
+                RepoManager.instance().add_repo(repo)
             else:
                 iface.messageBar().pushMessage(
                     "Error", "Could not initialize repository", level=Qgis.Warning


### PR DESCRIPTION
Fixes an error creating a new repo.
    
```python
    File "/Users/rcoup/Library/Application Support/QGIS/QGIS3/profiles/default/python/plugins/kart/gui/dockwidget.py", line 156, in wrapper
     f(*args)
    File "/Users/rcoup/Library/Application Support/QGIS/QGIS3/profiles/default/python/plugins/kart/kartapi.py", line 57, in inner
     return f(*args)
    File "/Users/rcoup/Library/Application Support/QGIS/QGIS3/profiles/default/python/plugins/kart/gui/dockwidget.py", line 251, in createRepo
     RepoManager.add_repo(repo)
    TypeError: add_repo() missing 1 required positional argument: 'repo'
```

(The repo is created on disk, the error occurs afterwards. Adding the new repo to the plugin works fine)

---

Looks like this interface was refactored as part of https://github.com/koordinates/kart-qgis-plugin/pull/96, but this one was missed. Update it to use the current pattern.