### PR TITLE
Clone: fix issue with dialog hiding

### DIFF
--- a/kart/gui/clonedialog.py
+++ b/kart/gui/clonedialog.py
@@ -5,6 +5,7 @@ from qgis.utils import iface
 from qgis.gui import QgsMessageBar
 
 from qgis.PyQt import uic
+from qgis.PyQt.QtCore import Qt
 from qgis.PyQt.QtWidgets import QDialog, QSizePolicy, QFileDialog
 
 from kart.gui.extentselectionpanel import ExtentSelectionPanel
@@ -51,6 +52,11 @@ class CloneDialog(BASE, WIDGET):
         )
         if folder:
             textbox.setText(folder)
+
+        self.show()
+        self.raise_()
+        self.setWindowState(self.windowState() & ~Qt.WindowMinimized)
+        self.activateWindow()
 
     def okClicked(self):
         try:


### PR DESCRIPTION
When selecting a source/destination folder during cloning, after the OS browser dialog was closed the clone dialog isn't re-focused and ended up hiding behind the main QGIS window. 

![CleanShot 2023-04-20 at 12 41 09](https://user-images.githubusercontent.com/59874/233355854-d161a239-e978-4cc5-a828-583b3f9a74ad.gif)
(at the end I hit ⌘` to bring the clone dialog back to the foreground)

Fix this by calling `self.raise_()` & `self.activateWindow()` after the folder is selected

@nyalldawson there are other places in the plugin which don't use this pattern, still use `QFileDialog` in the same way, and the plugin dialog _doesn't_ end up in the background... any idea why the clone dialog is different?