### PR TITLE
QGIS & Kart version updates

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -1,5 +1,5 @@
 ARG QGIS_TEST_VERSION=latest
-FROM  qgis/qgis:${QGIS_TEST_VERSION}
+FROM qgis/qgis:${QGIS_TEST_VERSION}
 
 RUN apt-get update && \
     apt-get install -y python3-pip
@@ -9,9 +9,11 @@ RUN pip3 install -r /tmp/requirements.txt
 COPY ./requirements_test.txt /tmp/
 RUN pip3 install -r /tmp/requirements_test.txt
 
-RUN apt-get install wget
-RUN wget -nv https://github.com/koordinates/kart/releases/download/v0.12.2/kart_0.12.2_amd64.deb
-RUN apt install -qy ./kart_0.12.2_amd64.deb
+ARG KART_VERSION
+RUN apt-get install -y wget
+RUN wget -nv https://github.com/koordinates/kart/releases/download/v${KART_VERSION}/kart_${KART_VERSION}_$(dpkg --print-architecture).deb
+RUN apt install -qy ./kart_${KART_VERSION}_$(dpkg --print-architecture).deb
+#RUN kart --version
 
 ENV LANG=C.UTF-8
 

--- a/.docker/docker-compose.gh.yml
+++ b/.docker/docker-compose.gh.yml
@@ -6,6 +6,7 @@ services:
       dockerfile: ./.docker/Dockerfile
       args:
         QGIS_TEST_VERSION: ${QGIS_TEST_VERSION}
+        KART_VERSION: ${KART_VERSION}
     tty: true
     volumes:
       - ${GITHUB_WORKSPACE}:/usr/src

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        qgis_version: [release-3_16, latest]
+        qgis_version: [release-3_28, latest]
       fail-fast: false
 
     env:

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   # Run unit tests
   test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     strategy:
       matrix:
@@ -21,6 +21,7 @@ jobs:
 
     env:
       QGIS_TEST_VERSION: ${{ matrix.qgis_version }}
+      KART_VERSION: "0.12.3"
 
     steps:
       - name: Checkout
@@ -28,5 +29,5 @@ jobs:
 
       - name: Test on QGIS
         run: >
-          docker-compose -f .docker/docker-compose.gh.yml
-          run qgis /usr/src/.docker/run-docker-tests.sh
+          docker-compose -f .docker/docker-compose.gh.yml run --build --rm
+          qgis /usr/src/.docker/run-docker-tests.sh

--- a/kart/kartapi.py
+++ b/kart/kartapi.py
@@ -39,7 +39,8 @@ from kart.gui.installationwarningdialog import InstallationWarningDialog
 from kart.utils import progressBar, setting, setSetting, KARTPATH, HELPERMODE
 from kart import logging
 
-SUPPORTED_VERSION = "0.12.2"
+
+SUPPORTED_VERSION = "0.12.3"
 
 
 class KartException(Exception):

--- a/kart/tests/test_kartapi.py
+++ b/kart/tests/test_kartapi.py
@@ -1,6 +1,7 @@
 import os
-import tempfile
+import re
 import shutil
+import tempfile
 
 from qgis.core import (
     edit,
@@ -79,7 +80,7 @@ class TestKartapi(unittest.TestCase):
 
     def testKartVersion(self):
         version = installedVersion()
-        assert version == "0.12.2"
+        assert re.match(r'\d+\.\d+\.\d+', version)
 
     def testStoreReposInSettings(self):
         manager = RepoManager()


### PR DESCRIPTION
- Update Kart to v0.12.3
- Update QGIS versions used for testing to v3.28 (current LTR) + latest
- Improvements to tests & test env setup