### PR TITLE
Update to kart 0.14.1

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -21,7 +21,7 @@ jobs:
 
     env:
       QGIS_TEST_VERSION: ${{ matrix.qgis_version }}
-      KART_VERSION: "0.14.0"
+      KART_VERSION: "0.14.1"
 
     steps:
       - name: Checkout

--- a/kart/gui/installationwarningdialog.py
+++ b/kart/gui/installationwarningdialog.py
@@ -33,15 +33,15 @@ class DownloadAndInstallThread(QThread):
     downloadFinished = pyqtSignal()
     finished = pyqtSignal()
 
-    def __init__(self, supportedVersion):
+    def __init__(self, version: str):
         QThread.__init__(self, iface.mainWindow())
-        self.supportedVersion = supportedVersion
+        self.version = version
 
     def run(self):
         try:
-            url = DOWNLOAD_URL.format(version=self.supportedVersion)
+            url = DOWNLOAD_URL.format(version=self.version)
             if os.name == "nt":
-                filename = WINDOWS_FILE.format(version=self.supportedVersion)
+                filename = WINDOWS_FILE.format(version=self.version)
                 msipath = self._download(url, filename)
                 powershell = os.path.join(
                     os.getenv("SystemRoot"),
@@ -57,14 +57,14 @@ class DownloadAndInstallThread(QThread):
                     subprocess.call(command, shell=True)
                     shutil.rmtree(os.path.dirname(msipath))
             elif sys.platform == "darwin":
-                filename = OSX_FILE.format(version=self.supportedVersion)
+                filename = OSX_FILE.format(version=self.version)
                 pkgpath = self._download(url, filename)
                 command = f"open -W {pkgpath}"
                 if pkgpath is not None:
                     subprocess.call(command, shell=True)
                     shutil.rmtree(os.path.dirname(pkgpath))
             else:
-                url = RELEASE_URL.format(version=self.supportedVersion)
+                url = RELEASE_URL.format(version=self.version)
                 webbrowser.open_new_tab(url)
         except Exception as e:
             logging.error(str(e))
@@ -92,10 +92,10 @@ class DownloadAndInstallThread(QThread):
 
 
 class InstallationWarningDialog(BASE, WIDGET):
-    def __init__(self, msg, supportedVersion):
+    def __init__(self, msg: str, version: str):
         super(QDialog, self).__init__(iface.mainWindow())
         self.setupUi(self)
-        self.supportedVersion = supportedVersion
+        self.version = version
         self.widgetDownload.setVisible(False)
         self.btnInstall.clicked.connect(self.install)
         self.btnOpenSettings.clicked.connect(self.openSettings)
@@ -114,7 +114,7 @@ class InstallationWarningDialog(BASE, WIDGET):
         self.btnClose.setEnabled(False)
         self.btnInstall.setEnabled(False)
         self.btnOpenSettings.setEnabled(False)
-        t = DownloadAndInstallThread(self.supportedVersion)
+        t = DownloadAndInstallThread(self.version)
         loop = QEventLoop()
         t.downloadProgressChanged.connect(self.progressBar.setValue)
         t.downloadFinished.connect(self.hide)

--- a/kart/kartapi.py
+++ b/kart/kartapi.py
@@ -37,7 +37,8 @@ from kart.utils import progressBar, setting, setSetting, KARTPATH, HELPERMODE
 from kart import logging
 
 
-SUPPORTED_VERSION = "0.14.0"
+MINIMUM_SUPPORTED_VERSION = "0.14.0"
+CURRENT_VERSION = "0.14.1"
 
 
 class KartException(Exception):
@@ -103,7 +104,8 @@ def kartExecutable() -> str:
 
 def checkKartInstalled(showMessage=True, useCache=True):
     version = installedVersion(useCache)
-    supported_major, supported_minor, supported_patch = SUPPORTED_VERSION.split(".")
+    supported_major, supported_minor, supported_patch = \
+        MINIMUM_SUPPORTED_VERSION.split(".")
     msg = ""
     if version is None:
         msg = (
@@ -121,15 +123,16 @@ def checkKartInstalled(showMessage=True, useCache=True):
         )
         if not versionOk:
             msg = (
-                f"<p><b>The installed Kart version ({version}) is different from the version"
-                f" supported by the plugin ({SUPPORTED_VERSION})<b><p>"
+                f"<p><b>The installed Kart version ({version}) is not"
+                " supported by the plugin. Only versions "
+                f"{MINIMUM_SUPPORTED_VERSION} and later are supported.<b><p>"
                 "<p>Click Install to download and install the latest Kart release. "
                 "You can also download releases from <a href='https://kartproject.org'>"
                 "https://kartproject.org</a>.</p>"
             )
     if msg:
         if showMessage:
-            dlg = InstallationWarningDialog(msg, SUPPORTED_VERSION)
+            dlg = InstallationWarningDialog(msg, CURRENT_VERSION)
             dlg.exec()
             installed = checkKartInstalled(showMessage=False, useCache=False)
             if installed:


### PR DESCRIPTION
And allow running with older releases if not required for plugin to function, whilst still always prompting to download the latest release.