### PR TITLE
Refactor icon usage for re-usability

### DIFF
--- a/kart/gui/conflictsdialog.py
+++ b/kart/gui/conflictsdialog.py
@@ -6,7 +6,7 @@ from qgis.gui import QgsMessageBar
 
 from qgis.PyQt import uic
 from qgis.PyQt.QtCore import QSize, Qt
-from qgis.PyQt.QtGui import QIcon, QFont
+from qgis.PyQt.QtGui import QFont
 from qgis.PyQt.QtWidgets import (
     QDialog,
     QTreeWidgetItem,
@@ -17,15 +17,8 @@ from qgis.PyQt.QtWidgets import (
     QTreeWidgetItemIterator,
 )
 
-pluginPath = os.path.split(os.path.dirname(__file__))[0]
+from kart.gui import icons
 
-
-def icon(f):
-    return QIcon(os.path.join(pluginPath, "img", f))
-
-
-layerIcon = icon("layer.png")
-featureIcon = icon("layer.png")
 
 WIDGET, BASE = uic.loadUiType(
     os.path.join(os.path.dirname(__file__), "conflictsdialog.ui")
@@ -84,7 +77,7 @@ class ConflictsDialog(BASE, WIDGET):
         for path, conflicts in self.conflicts.items():
             topItem = QTreeWidgetItem()
             topItem.setText(0, path)
-            topItem.setIcon(0, layerIcon)
+            topItem.setIcon(0, icons.layerIcon)
             self.treeConflicts.addTopLevelItem(topItem)
             self.treeItems[path] = {}
             for fid, conflict in conflicts.items():
@@ -352,7 +345,7 @@ class ConflictItem(QTreeWidgetItem):
     def __init__(self, path, fid, conflict):
         QTreeWidgetItem.__init__(self)
         self.setText(0, fid)
-        self.setIcon(0, featureIcon)
+        self.setIcon(0, icons.featureIcon)
         self.setSizeHint(0, QSize(self.sizeHint(0).width(), 25))
         self.conflict = conflict
         self.fid = fid

--- a/kart/gui/diffviewer.py
+++ b/kart/gui/diffviewer.py
@@ -6,7 +6,7 @@ import difflib
 
 from qgis.PyQt import uic
 from qgis.PyQt.QtCore import Qt, pyqtSignal
-from qgis.PyQt.QtGui import QIcon, QColor, QBrush
+from qgis.PyQt.QtGui import QColor, QBrush
 from qgis.PyQt.QtWidgets import (
     QVBoxLayout,
     QTableWidgetItem,
@@ -35,6 +35,8 @@ from qgis.utils import iface
 from qgis.gui import QgsMapCanvas, QgsMessageBar, QgsMapToolPan
 
 from .mapswipetool import MapSwipeTool
+
+from kart.gui import icons
 from kart.utils import setting, DIFFSTYLES
 
 ADDED, MODIFIED, REMOVED, UNCHANGED = 0, 1, 2, 3
@@ -52,17 +54,6 @@ TAB_GEOMETRY = 1
 
 pluginPath = os.path.split(os.path.dirname(__file__))[0]
 
-
-def icon(f):
-    return QIcon(os.path.join(pluginPath, "img", f))
-
-
-vectorDatasetIcon = icon("vector-polyline.png")
-tableIcon = icon("table.png")
-featureIcon = icon("geometry.png")
-addedIcon = icon("add.png")
-removedIcon = icon("remove.png")
-modifiedIcon = icon("edit.png")
 
 pointsStyle = os.path.join(
     pluginPath, "resources", "diff_styles", "geomdiff_points.qml"
@@ -311,13 +302,13 @@ class DiffViewerWidget(WIDGET, BASE):
             datasetItem = DatasetItem(dataset, crs is None)
             addedItem = QTreeWidgetItem()
             addedItem.setText(0, "Added")
-            addedItem.setIcon(0, addedIcon)
+            addedItem.setIcon(0, icons.addedIcon)
             removedItem = QTreeWidgetItem()
             removedItem.setText(0, "Removed")
-            removedItem.setIcon(0, removedIcon)
+            removedItem.setIcon(0, icons.removeIcon)
             modifiedItem = QTreeWidgetItem()
             modifiedItem.setText(0, "Modified")
-            modifiedItem.setIcon(0, modifiedIcon)
+            modifiedItem.setIcon(0, icons.modifiedIcon)
 
             subItems = {"I": addedItem, "U": modifiedItem, "D": removedItem}
             changes = {feat["id"]: feat for feat in changes}
@@ -627,7 +618,7 @@ class DiffViewerWidget(WIDGET, BASE):
 class FeatureItem(QTreeWidgetItem):
     def __init__(self, fid, old, new, dataset):
         QTreeWidgetItem.__init__(self)
-        self.setIcon(0, featureIcon)
+        self.setIcon(0, icons.featureIcon)
         self.setText(0, fid)
         self.old = old
         self.new = new
@@ -639,7 +630,7 @@ class DatasetItem(QTreeWidgetItem):
     def __init__(self, dataset, isTable):
         QTreeWidgetItem.__init__(self)
         self.dataset = dataset
-        self.setIcon(0, tableIcon if isTable else vectorDatasetIcon)
+        self.setIcon(0, icons.tableIcon if isTable else icons.vectorDatasetIcon)
         self.setText(0, dataset)
 
 

--- a/kart/gui/dockwidget.py
+++ b/kart/gui/dockwidget.py
@@ -4,7 +4,6 @@ import tempfile
 from qgis.PyQt import uic
 from qgis.PyQt.QtCore import Qt, QMimeData, QByteArray, QDataStream, QIODevice
 
-from qgis.PyQt.QtGui import QIcon
 from qgis.PyQt.QtWidgets import (
     QDockWidget,
     QTreeWidgetItem,
@@ -32,6 +31,7 @@ from kart.kartapi import (
     KartException,
     checkKartInstalled,
 )
+from kart.gui import icons
 from kart.gui.diffviewer import DiffViewerDialog
 from kart.gui.historyviewer import HistoryDialog
 from kart.gui.conflictsdialog import ConflictsDialog
@@ -53,35 +53,6 @@ from kart.utils import (
 )
 
 pluginPath = os.path.split(os.path.dirname(__file__))[0]
-
-
-def icon(f):
-    return QIcon(os.path.join(pluginPath, "img", f))
-
-
-repoIcon = icon("repository.png")
-addRepoIcon = icon("addrepo.png")
-createRepoIcon = icon("createrepo.png")
-cloneRepoIcon = icon("clone.png")
-logIcon = icon("log.png")
-importIcon = icon("import.png")
-checkoutIcon = icon("checkout.png")
-commitIcon = icon("commit.png")
-discardIcon = icon("reset.png")
-datasetIcon = icon("dataset.png")
-vectorDatasetIcon = icon("vector-polyline.png")
-tableIcon = icon("table.png")
-mergeIcon = icon("merge.png")
-addtoQgisIcon = icon("openinqgis.png")
-diffIcon = icon("changes.png")
-abortIcon = icon("abort.png")
-resolveIcon = icon("resolve.png")
-pushIcon = icon("push.png")
-pullIcon = icon("pull.png")
-removeIcon = icon("remove.png")
-refreshIcon = icon("refresh.png")
-propertiesIcon = icon("info.png")
-patchIcon = icon("patch.png")
 
 WIDGET, BASE = uic.loadUiType(os.path.join(os.path.dirname(__file__), "dockwidget.ui"))
 
@@ -172,7 +143,7 @@ class KartDockWidget(BASE, WIDGET):
 class RefreshableItem(QTreeWidgetItem):
     def actions(self):
         actions = [
-            ("Refresh", self.refreshContent, refreshIcon),
+            ("Refresh", self.refreshContent, icons.refreshIcon),
             ("divider", None, None),
         ]
         actions.extend(self._actions())
@@ -188,7 +159,7 @@ class ReposItem(RefreshableItem):
         QTreeWidgetItem.__init__(self)
 
         self.setText(0, "Repositories")
-        self.setIcon(0, repoIcon)
+        self.setIcon(0, icons.repoIcon)
         self.setChildIndicatorPolicy(QTreeWidgetItem.ShowIndicator)
 
         self.populate()
@@ -202,9 +173,9 @@ class ReposItem(RefreshableItem):
 
     def _actions(self):
         actions = [
-            ("Add existing repository...", self.addRepo, addRepoIcon),
-            ("Create new repository...", self.createRepo, createRepoIcon),
-            ("Clone repository...", self.cloneRepo, cloneRepoIcon),
+            ("Add existing repository...", self.addRepo, icons.addRepoIcon),
+            ("Create new repository...", self.createRepo, icons.createRepoIcon),
+            ("Clone repository...", self.cloneRepo, icons.cloneRepoIcon),
         ]
 
         return actions
@@ -284,7 +255,7 @@ class RepoItem(RefreshableItem):
         self.populated = False
 
         self.setTitle()
-        self.setIcon(0, repoIcon)
+        self.setIcon(0, icons.repoIcon)
         self.setChildIndicatorPolicy(QTreeWidgetItem.ShowIndicator)
 
     def refreshContent(self):
@@ -323,44 +294,52 @@ class RepoItem(RefreshableItem):
         if self.repo.isMerging():
             actions.extend(
                 [
-                    ("Resolve conflicts...", self.resolveConflicts, resolveIcon),
-                    ("Continue merge", self.continueMerge, mergeIcon),
-                    ("Abort merge", self.abortMerge, abortIcon),
+                    ("Resolve conflicts...", self.resolveConflicts, icons.resolveIcon),
+                    ("Continue merge", self.continueMerge, icons.mergeIcon),
+                    ("Abort merge", self.abortMerge, icons.abortIcon),
                 ]
             )
         else:
             actions.extend(
                 [
-                    ("Show log...", self.showLog, logIcon),
-                    ("Show working copy changes...", self.showChanges, diffIcon),
-                    ("Discard working copy changes", self.discardChanges, discardIcon),
-                    ("Commit working copy changes...", self.commitChanges, commitIcon),
-                    ("Switch branch...", self.switchBranch, checkoutIcon),
-                    ("Merge into current branch...", self.mergeBranch, mergeIcon),
+                    ("Show log...", self.showLog, icons.logIcon),
+                    ("Show working copy changes...", self.showChanges, icons.diffIcon),
+                    (
+                        "Discard working copy changes",
+                        self.discardChanges,
+                        icons.discardIcon,
+                    ),
+                    (
+                        "Commit working copy changes...",
+                        self.commitChanges,
+                        icons.commitIcon,
+                    ),
+                    ("Switch branch...", self.switchBranch, icons.checkoutIcon),
+                    ("Merge into current branch...", self.mergeBranch, icons.mergeIcon),
                     ("divider", None, None),
-                    ("Pull...", self.pull, pullIcon),
-                    ("Push...", self.push, pushIcon),
+                    ("Pull...", self.pull, icons.pullIcon),
+                    ("Push...", self.push, icons.pushIcon),
                     ("divider", None, None),
                     (
                         "Import dataset from file...",
                         self.importLayerFromFile,
-                        importIcon,
+                        icons.importIcon,
                     ),
                     (
                         "Import dataset from database...",
                         self.importLayerFromDatabase,
-                        importIcon,
+                        icons.importIcon,
                     ),
-                    ("Apply patch...", self.applyPatch, patchIcon),
+                    ("Apply patch...", self.applyPatch, icons.patchIcon),
                 ]
             )
 
         actions.extend(
             [
                 ("divider", None, None),
-                ("Refresh", self.refreshContent, refreshIcon),
-                ("Properties...", self.showProperties, propertiesIcon),
-                ("Remove this repository", self.removeRepository, removeIcon),
+                ("Refresh", self.refreshContent, icons.refreshIcon),
+                ("Properties...", self.showProperties, icons.propertiesIcon),
+                ("Remove this repository", self.removeRepository, icons.removeIcon),
             ]
         )
 
@@ -624,7 +603,7 @@ class DatasetsItem(RefreshableItem):
         self.repo = repo
 
         self.setText(0, "Datasets")
-        self.setIcon(0, datasetIcon)
+        self.setIcon(0, icons.datasetIcon)
 
         self.populate()
 
@@ -650,32 +629,32 @@ class DatasetItem(QTreeWidgetItem):
         self.isTable = isTable
 
         self.setText(0, name)
-        self.setIcon(0, tableIcon if isTable else vectorDatasetIcon)
+        self.setIcon(0, icons.tableIcon if isTable else icons.vectorDatasetIcon)
 
     def actions(self):
-        actions = [("Add to QGIS project", self.addToProject, addtoQgisIcon)]
+        actions = [("Add to QGIS project", self.addToProject, icons.addtoQgisIcon)]
         if not self.repo.isMerging():
             actions.extend(
                 [
                     ("divider", None, None),
-                    ("Show log...", self.showLog, logIcon),
+                    ("Show log...", self.showLog, icons.logIcon),
                     (
                         "Show working copy changes for this dataset...",
                         self.showChanges,
-                        diffIcon,
+                        icons.diffIcon,
                     ),
                     (
                         "Discard working copy changes for this dataset",
                         self.discardChanges,
-                        discardIcon,
+                        icons.discardIcon,
                     ),
                     (
                         "Commit working copy changes for this dataset...",
                         self.commitChanges,
-                        commitIcon,
+                        icons.commitIcon,
                     ),
                     ("divider", None, None),
-                    ("Remove from repository", self.removeFromRepo, removeIcon),
+                    ("Remove from repository", self.removeFromRepo, icons.removeIcon),
                 ]
             )
 

--- a/kart/gui/historyviewer.py
+++ b/kart/gui/historyviewer.py
@@ -2,6 +2,7 @@ import json
 import os
 
 from kart.kartapi import executeskart
+from kart.gui import icons
 from kart.gui.diffviewer import DiffViewerDialog
 from kart.utils import setting, DIFFSTYLES
 
@@ -17,7 +18,6 @@ from qgis.PyQt.QtCore import (
     QDateTime,
 )
 from qgis.PyQt.QtGui import (
-    QIcon,
     QPixmap,
     QPainter,
     QColor,
@@ -59,22 +59,6 @@ COLORS = [
     QColor(Qt.cyan),
     QColor(Qt.magenta),
 ]
-
-
-def icon(f):
-    return QIcon(os.path.join(os.path.dirname(os.path.dirname(__file__)), "img", f))
-
-
-resetIcon = icon("reset.png")
-diffIcon = icon("changes.png")
-checkoutIcon = icon("checkout.png")
-mergeIcon = icon("merge.png")
-createBranchIcon = icon("createbranch.png")
-deleteIcon = icon("delete.png")
-createTagIcon = icon("label.png")
-restoreIcon = icon("checkout.png")
-patchIcon = icon("patch.png")
-addtoQgisIcon = icon("openinqgis.png")
 
 
 class HistoryTree(QTreeWidget):
@@ -120,18 +104,18 @@ class HistoryTree(QTreeWidget):
                         item.commit["commit"],
                         parents[0],
                     ),
-                    diffIcon,
+                    icons.diffIcon,
                 )
                 actions["Save changes as patch..."] = (
                     _f(
                         self.savePatch,
                         item.commit["commit"],
                     ),
-                    patchIcon,
+                    icons.patchIcon,
                 )
                 actions["Add changes to current QGIS project as vector layer"] = (
                     _f(self.saveAsLayer, item.commit["commit"], parents[0]),
-                    addtoQgisIcon,
+                    icons.addtoQgisIcon,
                 )
             elif len(parents) > 1:
                 for parent in parents:
@@ -143,25 +127,25 @@ class HistoryTree(QTreeWidget):
                             item.commit["commit"],
                             parent,
                         ),
-                        diffIcon,
+                        icons.diffIcon,
                     )
             actions.update(
                 {
                     "Reset current branch to this commit": (
                         _f(self.resetBranch, item),
-                        resetIcon,
+                        icons.resetIcon,
                     ),
                     "Create branch at this commit...": (
                         _f(self.createBranch, item),
-                        createBranchIcon,
+                        icons.createBranchIcon,
                     ),
                     "Create tag at this commit...": (
                         _f(self.createTag, item),
-                        createTagIcon,
+                        icons.createTagIcon,
                     ),
                     "Restore working tree datasets to this version...": (
                         _f(self.restoreDatasets, item),
-                        restoreIcon,
+                        icons.restoreIcon,
                     ),
                 }
             )
@@ -173,16 +157,16 @@ class HistoryTree(QTreeWidget):
                     tag = ref[4:].strip()
                     actions[f"Delete tag '{tag}'"] = (
                         _f(self.deleteTag, tag),
-                        deleteIcon,
+                        icons.deleteIcon,
                     )
                 else:
                     actions[f"Switch to branch '{ref}'"] = (
                         _f(self.switchBranch, ref),
-                        checkoutIcon,
+                        icons.checkoutIcon,
                     )
                     actions[f"Delete branch '{ref}'"] = (
                         _f(self.deleteBranch, ref),
-                        deleteIcon,
+                        icons.deleteIcon,
                     )
         elif selected and len(selected) == 2:
             itema = selected[0]
@@ -194,7 +178,7 @@ class HistoryTree(QTreeWidget):
                         itema.commit["commit"],
                         itemb.commit["commit"],
                     ),
-                    diffIcon,
+                    icons.diffIcon,
                 )
             }
         else:

--- a/kart/gui/icons.py
+++ b/kart/gui/icons.py
@@ -1,0 +1,46 @@
+import os
+
+from qgis.PyQt.QtGui import QIcon
+
+_pluginPath = os.path.split(os.path.dirname(__file__))[0]
+
+
+def icon(f):
+    return QIcon(os.path.join(_pluginPath, "img", f))
+
+
+abortIcon = icon("abort.png")
+aboutIcon = icon("info.png")
+addedIcon = icon("add.png")
+addRepoIcon = icon("addrepo.png")
+addtoQgisIcon = icon("openinqgis.png")
+checkoutIcon = icon("checkout.png")
+cloneRepoIcon = icon("clone.png")
+commitIcon = icon("commit.png")
+createBranchIcon = icon("createbranch.png")
+createRepoIcon = icon("createrepo.png")
+crossIcon = icon("cross.png")
+datasetIcon = icon("dataset.png")
+deleteIcon = icon("delete.png")
+diffIcon = icon("changes.png")
+discardIcon = icon("reset.png")
+featureIcon = icon("layer.png")
+importIcon = icon("import.png")
+kartIcon = icon("kart.png")
+layerIcon = icon("layer.png")
+logIcon = icon("log.png")
+mergeIcon = icon("merge.png")
+modifiedIcon = icon("edit.png")
+patchIcon = icon("patch.png")
+propertiesIcon = icon("info.png")
+pullIcon = icon("pull.png")
+pushIcon = icon("push.png")
+refreshIcon = icon("refresh.png")
+removeIcon = icon("remove.png")
+repoIcon = icon("repository.png")
+resetIcon = icon("reset.png")
+resolveIcon = icon("resolve.png")
+restoreIcon = icon("checkout.png")
+settingsIcon = icon("settings.png")
+tableIcon = icon("table.png")
+vectorDatasetIcon = icon("vector-polyline.png")

--- a/kart/kartapi.py
+++ b/kart/kartapi.py
@@ -62,7 +62,7 @@ def executeskart(f):
             msglines = []
             for line in lines:
                 # skip lines that refer to missing loads of shared libraries
-                if line.startswith("ERROR 1: Can't load") or '.dylib' in line:
+                if line.startswith("ERROR 1: Can't load") or ".dylib" in line:
                     continue
                 if "The specified procedure could not be found" in line:
                     continue
@@ -211,7 +211,7 @@ def executeKart(commands, path=None, jsonoutput=False, feedback=None):
             executeKart.env.pop("GDAL_DRIVER_PATH")
 
     # always set the use helper env var as it is long lived and the setting may have changed
-    executeKart.env['KART_USE_HELPER'] = '1' if setting(HELPERMODE) else ''
+    executeKart.env["KART_USE_HELPER"] = "1" if setting(HELPERMODE) else ""
 
     try:
         encoding = locale.getdefaultlocale()[1] or "utf-8"
@@ -342,7 +342,7 @@ class Repository:
         extent: Optional[QgsReferencedRectangle] = None,
         username: Optional[str] = None,
         password: Optional[str] = None,
-    ) -> 'Repository':
+    ) -> "Repository":
         """
         Performs a (blocking, main thread only) clone operation
         """

--- a/kart/layers.py
+++ b/kart/layers.py
@@ -20,28 +20,16 @@ from qgis.core import (
 from qgis.gui import QgsMapToolEmitPoint, QgsRubberBand
 
 from qgis.PyQt.QtCore import Qt, QSizeF, QPointF
-from qgis.PyQt.QtGui import QIcon, QColor, QTextDocument
+from qgis.PyQt.QtGui import QColor, QTextDocument
 from qgis.PyQt.QtWidgets import QAction, QInputDialog
 
+from kart.gui import icons
 from kart.gui.historyviewer import HistoryDialog
 from kart.gui.diffviewer import DiffViewerDialog
 from kart.gui.featurehistorydialog import FeatureHistoryDialog
 from kart.kartapi import executeskart
 from kart.utils import setting, AUTOCOMMIT
 from kart.core import RepoManager
-
-pluginPath = os.path.dirname(__file__)
-
-
-def icon(f):
-    return QIcon(os.path.join(pluginPath, "img", f))
-
-
-logIcon = icon("log.png")
-commitIcon = icon("commit.png")
-discardIcon = icon("reset.png")
-crossIcon = icon("cross.png")
-diffIcon = icon("changes.png")
 
 
 def _f(f, *args):
@@ -74,14 +62,14 @@ class LayerTracker:
         self.mapTool.canvasClicked.connect(self.canvasClicked)
         self.mapToolLayer = None
 
-        self.showLogAction = QAction(logIcon, "Show Log...", iface)
+        self.showLogAction = QAction(icons.logIcon, "Show Log...", iface)
         self.showLogAction.triggered.connect(_f(self.showLog))
         iface.addCustomActionForLayerType(
             self.showLogAction, "Kart", QgsMapLayer.VectorLayer, False
         )
 
         self.showWorkingTreeChangesAction = QAction(
-            diffIcon, "Show working copy changes...", iface
+            icons.diffIcon, "Show working copy changes...", iface
         )
         self.showWorkingTreeChangesAction.triggered.connect(
             _f(self.showWorkingTreeChanges)
@@ -91,7 +79,7 @@ class LayerTracker:
         )
 
         self.discardWorkingTreeChangesAction = QAction(
-            discardIcon, "Discard working copy changes...", iface
+            icons.discardIcon, "Discard working copy changes...", iface
         )
         self.discardWorkingTreeChangesAction.triggered.connect(
             _f(self.discardWorkingTreeChanges)
@@ -101,7 +89,7 @@ class LayerTracker:
         )
 
         self.commitWorkingTreeChangesAction = QAction(
-            commitIcon, "Commit working copy changes...", iface
+            icons.commitIcon, "Commit working copy changes...", iface
         )
         self.commitWorkingTreeChangesAction.triggered.connect(
             _f(self.commitWorkingTreeChanges)
@@ -111,7 +99,7 @@ class LayerTracker:
         )
 
         self.setMapToolAction = QAction(
-            crossIcon, "Activate 'show feature history' map tool", iface
+            icons.crossIcon, "Activate 'show feature history' map tool", iface
         )
         self.setMapToolAction.triggered.connect(_f(self.setMapTool))
         iface.addCustomActionForLayerType(

--- a/kart/plugin.py
+++ b/kart/plugin.py
@@ -6,23 +6,14 @@ from qgis.core import QgsProject, Qgis, QgsMessageOutput
 
 from qgis.PyQt.QtCore import Qt
 from qgis.PyQt.QtWidgets import QAction
-from qgis.PyQt.QtGui import QIcon
 
 from kart.gui.dockwidget import KartDockWidget
 from kart.gui.settingsdialog import SettingsDialog
 from kart.kartapi import checkKartInstalled, kartVersionDetails
 from kart.layers import LayerTracker
 
+
 pluginPath = os.path.dirname(__file__)
-
-
-def icon(f):
-    return QIcon(os.path.join(pluginPath, "img", f))
-
-
-kartIcon = icon("kart.png")
-settingsIcon = icon("settings.png")
-aboutIcon = icon("info.png")
 
 
 class KartPlugin(object):


### PR DESCRIPTION
Shuffles the icons used by the GUI components into `kart.gui.icons`.

There should be no user-visible changes as a result of this PR, however it simplifies future re-use of Kart plugin icons.