### PR TITLE
Migrate to v2 Docker Compose & Update QGIS/Kart Versions

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -1,6 +1,8 @@
 ARG QGIS_TEST_VERSION=latest
 FROM qgis/qgis:${QGIS_TEST_VERSION}
 
+ENV PIP_BREAK_SYSTEM_PACKAGES 1
+
 RUN apt-get update && \
     apt-get install -y python3-pip
 COPY ./requirements.txt /tmp/

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -16,12 +16,12 @@ jobs:
 
     strategy:
       matrix:
-        qgis_version: [release-3_28, latest]
+        qgis_version: [release-3_34, latest]
       fail-fast: false
 
     env:
       QGIS_TEST_VERSION: ${{ matrix.qgis_version }}
-      KART_VERSION: "0.15.0"
+      KART_VERSION: "0.15.2"
 
     steps:
       - name: Checkout

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -29,5 +29,5 @@ jobs:
 
       - name: Test on QGIS
         run: >
-          docker-compose -f .docker/docker-compose.gh.yml run --build --rm
+          docker compose -f .docker/docker-compose.gh.yml run --build --rm
           qgis /usr/src/.docker/run-docker-tests.sh

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -2,5 +2,5 @@
 
 cd $(dirname $0)/..
 export GITHUB_WORKSPACE=$PWD
-docker-compose -f .docker/docker-compose.gh.yml run qgis /usr/src/.docker/run-docker-tests.sh $@
-docker-compose -f .docker/docker-compose.gh.yml rm -s -f
+docker compose -f .docker/docker-compose.gh.yml run qgis /usr/src/.docker/run-docker-tests.sh $@
+docker compose -f .docker/docker-compose.gh.yml rm -s -f


### PR DESCRIPTION
Tests were failing due to GitHub deprecating docker compose v1. This makes minor adjustments to support v2 as well as updating our Kart and QGIS targets.

Note that latest QGIS docker images have externally managed python installations, however for the purposes of testing we're happy to set `PIP_BREAK_SYSTEM_PACKAGES=1`. We don't actually require any additional dependancies in the plugin. If we need them in future we should consider the steps in https://github.com/qgis/QGIS/tree/master/.docker#running-tests-for-a-python-plugin which include installing the plugin into QGIS.