### PR TITLE
Initial processing support for the Kart plugin

### DIFF
--- a/kart/gui/dockwidget.py
+++ b/kart/gui/dockwidget.py
@@ -258,12 +258,12 @@ class ReposItem(RefreshableItem):
             with progressBar("Clone") as bar:
                 bar.setText("Cloning repository")
                 repo = Repository.clone(
-                    dialog.src,
-                    dialog.dst,
-                    dialog.location,
-                    dialog.extent,
-                    dialog.username,
-                    dialog.password,
+                    src=dialog.src,
+                    dst=dialog.dst,
+                    location=dialog.location,
+                    extent=dialog.extent,
+                    username=dialog.username,
+                    password=dialog.password,
                     output_handler=partial(_processProgressLine, bar),
                 )
             RepoManager.instance().add_repo(repo)

--- a/kart/kartapi.py
+++ b/kart/kartapi.py
@@ -293,6 +293,7 @@ class Repository:
         dst: str,
         location: Optional[str] = None,
         extent: Optional[QgsReferencedRectangle] = None,
+        depth: Optional[int] = None,
         username: Optional[str] = None,
         password: Optional[str] = None,
     ) -> List[str]:
@@ -313,6 +314,8 @@ class Repository:
         if extent is not None:
             kart_extent = f"{extent.crs().authid()};{extent.asWktPolygon()}"
             commands.extend(["--spatial-filter", kart_extent])
+        if depth is not None:
+            commands.extend(["--depth", str(depth)])
 
         return commands
 
@@ -322,6 +325,7 @@ class Repository:
         dst: str,
         location: Optional[str] = None,
         extent: Optional[QgsReferencedRectangle] = None,
+        depth: Optional[int] = None,
         username: Optional[str] = None,
         password: Optional[str] = None,
         output_handler: Callable[[str], None] = None,
@@ -330,7 +334,7 @@ class Repository:
         Performs a (blocking, main thread only) clone operation
         """
         commands = Repository.generate_clone_arguments(
-            src, dst, location, extent, username, password
+            src, dst, location, extent, depth, username, password
         )
         executeKart(commands, feedback=output_handler)
         return Repository(dst)
@@ -396,8 +400,11 @@ class Repository:
         else:
             self.executeKart(["init"])
 
-    def importIntoRepo(self, source):
-        self.executeKart(["import", source])
+    def importIntoRepo(self, source, dataset=None):
+        importArgs = [source]
+        if dataset:
+            importArgs += ["--dataset", dataset]
+        self.executeKart(["import"] + importArgs)
 
     def checkUserConfigured(self):
         configDict = self._config()

--- a/kart/kartapi.py
+++ b/kart/kartapi.py
@@ -212,6 +212,11 @@ def executeKart(commands, path=None, jsonoutput=False, feedback=None):
     # always set the use helper env var as it is long lived and the setting may have changed
     executeKart.env["KART_USE_HELPER"] = "1" if setting(HELPERMODE) else ""
 
+    # TODO - merge into Kart proper already
+    logging.debug("Enabling VPC/VRTs generation...")
+    executeKart.env["KART_POINT_CLOUD_VPCS"] = "1"
+    executeKart.env["KART_RASTER_VRTS"] = "1"
+
     try:
         encoding = locale.getdefaultlocale()[1] or "utf-8"
         QApplication.setOverrideCursor(Qt.WaitCursor)

--- a/kart/metadata.txt
+++ b/kart/metadata.txt
@@ -23,3 +23,4 @@ repository=https://github.com/koordinates/kart-qgis-plugin
 tracker=https://github.com/koordinates/kart-qgis-plugin/issues
 icon=img/kart.png
 category=Plugins
+hasProcessingProvider=yes

--- a/kart/plugin.py
+++ b/kart/plugin.py
@@ -2,7 +2,7 @@ import configparser
 import os
 import platform
 
-from qgis.core import QgsProject, Qgis, QgsMessageOutput
+from qgis.core import QgsApplication, QgsProject, Qgis, QgsMessageOutput
 
 from qgis.PyQt.QtCore import Qt
 from qgis.PyQt.QtWidgets import QAction
@@ -11,6 +11,7 @@ from kart.gui.dockwidget import KartDockWidget
 from kart.gui.settingsdialog import SettingsDialog
 from kart.kartapi import checkKartInstalled, kartVersionDetails
 from kart.layers import LayerTracker
+from kart.processing import KartProvider
 
 
 pluginPath = os.path.dirname(__file__)
@@ -19,6 +20,11 @@ pluginPath = os.path.dirname(__file__)
 class KartPlugin(object):
     def __init__(self, iface):
         self.iface = iface
+        self.provider = None
+
+    def initProcessing(self):
+        self.provider = KartProvider()
+        QgsApplication.processingRegistry().addProvider(self.provider)
 
     def initGui(self):
 
@@ -42,6 +48,8 @@ class KartPlugin(object):
         QgsProject.instance().layerRemoved.connect(self.tracker.layerRemoved)
         QgsProject.instance().layerWasAdded.connect(self.tracker.layerAdded)
         QgsProject.instance().crsChanged.connect(self.tracker.updateRubberBands)
+
+        self.initProcessing()
 
     def showDock(self):
         if checkKartInstalled():
@@ -87,3 +95,5 @@ class KartPlugin(object):
 
         QgsProject.instance().layerRemoved.disconnect(self.tracker.layerRemoved)
         QgsProject.instance().layerWasAdded.disconnect(self.tracker.layerAdded)
+
+        QgsApplication.processingRegistry().removeProvider(self.provider)

--- a/kart/processing/__init__.py
+++ b/kart/processing/__init__.py
@@ -1,0 +1,32 @@
+from qgis.core import QgsProcessingProvider
+
+from kart.gui import icons
+
+from .branches import RepoCreateBranch, RepoDeleteBranch, RepoSwitchBranch
+from .data import RepoImportData
+from .remotes import RepoPullFromRemote, RepoPushToRemote
+from .repos import RepoClone, RepoInit
+from .tags import RepoCreateTag
+
+
+class KartProvider(QgsProcessingProvider):
+    def loadAlgorithms(self, *args, **kwargs):
+
+        self.addAlgorithm(RepoInit())
+        self.addAlgorithm(RepoClone())
+        self.addAlgorithm(RepoCreateTag())
+        self.addAlgorithm(RepoSwitchBranch())
+        self.addAlgorithm(RepoCreateBranch())
+        self.addAlgorithm(RepoDeleteBranch())
+        self.addAlgorithm(RepoImportData())
+        self.addAlgorithm(RepoPullFromRemote())
+        self.addAlgorithm(RepoPushToRemote())
+
+    def id(self, *args, **kwargs):
+        return "Kart"
+
+    def name(self, *args, **kwargs):
+        return self.tr("Kart")
+
+    def icon(self):
+        return icons.kartIcon

--- a/kart/processing/base.py
+++ b/kart/processing/base.py
@@ -1,0 +1,16 @@
+from qgis.PyQt.QtCore import QCoreApplication
+from qgis.core import QgsProcessingAlgorithm
+
+
+class KartAlgorithm(QgsProcessingAlgorithm):
+    def createInstance(self):
+        return type(self)()
+
+    def name(self):
+        return f"kart_{self.__class__.__name__.lower()}"
+
+    def tr(self, string):
+        return QCoreApplication.translate("Processing", string)
+
+    def initAlgorithm(self, config=None):
+        return {}

--- a/kart/processing/branches.py
+++ b/kart/processing/branches.py
@@ -38,7 +38,7 @@ class RepoCreateBranch(KartAlgorithm):
         from kart.kartapi import Repository
 
         repo_path = self.parameterAsFile(parameters, self.REPO_PATH, context)
-        branch_name = self.parameterAsString(parameters, self.REPO_REFISH, context)
+        branch_name = self.parameterAsString(parameters, self.REPO_BRANCH_NAME, context)
 
         repo = Repository(repo_path)
         repo.createBranch(branch_name)

--- a/kart/processing/branches.py
+++ b/kart/processing/branches.py
@@ -1,0 +1,136 @@
+from qgis.core import QgsProcessingParameterFile, QgsProcessingParameterString
+from kart.gui import icons
+
+from .base import KartAlgorithm
+
+
+class RepoCreateBranch(KartAlgorithm):
+    REPO_PATH = "REPO_PATH"
+    REPO_BRANCH_NAME = "REPO_BRANCH_NAME"
+
+    def displayName(self):
+        return self.tr("Create Branch")
+
+    def shortHelpString(self):
+        return self.tr("Create a new branch")
+
+    def icon(self):
+        return icons.createBranchIcon
+
+    def initAlgorithm(self, config=None):
+
+        self.addParameter(
+            QgsProcessingParameterFile(
+                self.REPO_PATH,
+                self.tr("Repo Path"),
+                behavior=QgsProcessingParameterFile.Folder,
+            )
+        )
+
+        self.addParameter(
+            QgsProcessingParameterString(
+                self.REPO_BRANCH_NAME,
+                self.tr("Branch Name"),
+            )
+        )
+
+    def processAlgorithm(self, parameters, context, feedback):
+        from kart.kartapi import Repository
+
+        repo_path = self.parameterAsFile(parameters, self.REPO_PATH, context)
+        branch_name = self.parameterAsString(parameters, self.REPO_REFISH, context)
+
+        repo = Repository(repo_path)
+        repo.createBranch(branch_name)
+
+        return {
+            self.REPO_PATH: repo_path,
+        }
+
+
+class RepoSwitchBranch(KartAlgorithm):
+    REPO_PATH = "REPO_PATH"
+    REPO_BRANCH_NAME = "REPO_BRANCH_NAME"
+
+    def displayName(self):
+        return self.tr("Switch to Branch")
+
+    def shortHelpString(self):
+        return self.tr("Switches to a named branch")
+
+    def icon(self):
+        return icons.checkoutIcon
+
+    def initAlgorithm(self, config=None):
+
+        self.addParameter(
+            QgsProcessingParameterFile(
+                self.REPO_PATH,
+                self.tr("Repo Path"),
+                behavior=QgsProcessingParameterFile.Folder,
+            )
+        )
+
+        self.addParameter(
+            QgsProcessingParameterString(
+                self.REPO_BRANCH_NAME,
+                self.tr("Branch Name"),
+            )
+        )
+
+    def processAlgorithm(self, parameters, context, feedback):
+        from kart.kartapi import Repository
+
+        repo_path = self.parameterAsFile(parameters, self.REPO_PATH, context)
+        branch_name = self.parameterAsString(parameters, self.REPO_BRANCH_NAME, context)
+
+        repo = Repository(repo_path)
+        repo.checkoutBranch(branch_name)
+
+        return {
+            self.REPO_PATH: repo_path,
+        }
+
+
+class RepoDeleteBranch(KartAlgorithm):
+    REPO_PATH = "REPO_PATH"
+    REPO_BRANCH_NAME = "REPO_BRANCH_NAME"
+
+    def displayName(self):
+        return self.tr("Delete Branch")
+
+    def shortHelpString(self):
+        return self.tr("Delete a branch")
+
+    def icon(self):
+        return icons.deleteIcon
+
+    def initAlgorithm(self, config=None):
+
+        self.addParameter(
+            QgsProcessingParameterFile(
+                self.REPO_PATH,
+                self.tr("Repo Path"),
+                behavior=QgsProcessingParameterFile.Folder,
+            )
+        )
+
+        self.addParameter(
+            QgsProcessingParameterString(
+                self.REPO_BRANCH_NAME,
+                self.tr("Branch Name"),
+            )
+        )
+
+    def processAlgorithm(self, parameters, context, feedback):
+        from kart.kartapi import Repository
+
+        repo_path = self.parameterAsFile(parameters, self.REPO_PATH, context)
+        branch_name = self.parameterAsString(parameters, self.REPO_BRANCH_NAME, context)
+
+        repo = Repository(repo_path)
+        repo.deleteBranch(branch_name)
+
+        return {
+            self.REPO_PATH: repo_path,
+        }

--- a/kart/processing/data.py
+++ b/kart/processing/data.py
@@ -1,0 +1,73 @@
+from qgis.core import (
+    QgsProcessingParameterFile,
+    QgsProcessingParameterString,
+    QgsProcessingOutputFolder,
+)
+from kart.gui import icons
+
+from .base import KartAlgorithm
+
+
+class RepoImportData(KartAlgorithm):
+    REPO_PATH = "REPO_PATH"
+    REPO_DATA_PATH = "REPO_DATA_PATH"
+    REPO_DATASET_NAME = "REPO_DATASET_NAME"
+
+    def displayName(self):
+        return self.tr("Import Data")
+
+    def shortHelpString(self):
+        return self.tr("Import data into a repository")
+
+    def icon(self):
+        return icons.importIcon
+
+    def initAlgorithm(self, config=None):
+
+        self.addParameter(
+            QgsProcessingParameterFile(
+                self.REPO_PATH,
+                self.tr("Repo Path"),
+                behavior=QgsProcessingParameterFile.Folder,
+            )
+        )
+
+        self.addParameter(
+            QgsProcessingParameterFile(
+                self.REPO_DATA_PATH,
+                self.tr("Data Path"),
+                behavior=QgsProcessingParameterFile.File,
+            )
+        )
+
+        self.addParameter(
+            QgsProcessingParameterString(
+                self.REPO_DATASET_NAME,
+                self.tr("Dataset Name"),
+                optional=True,
+            )
+        )
+
+        self.addOutput(
+            QgsProcessingOutputFolder(
+                self.REPO_PATH,
+                self.tr("Repo Path"),
+            )
+        )
+
+    def processAlgorithm(self, parameters, context, feedback):
+        from kart.kartapi import Repository
+
+        repo_path = self.parameterAsFile(parameters, self.REPO_PATH, context)
+        data_path = self.parameterAsFile(parameters, self.REPO_DATA_PATH, context)
+        dataset_name = self.parameterAsString(
+            parameters, self.REPO_DATASET_NAME, context
+        )
+
+        repo = Repository(repo_path)
+        repo.importIntoRepo(data_path, dataset_name)
+
+        return {
+            self.REPO_PATH: repo_path,
+            self.REPO_DATASET_NAME: dataset_name,
+        }

--- a/kart/processing/remotes.py
+++ b/kart/processing/remotes.py
@@ -1,0 +1,112 @@
+from qgis.core import QgsProcessingParameterFile, QgsProcessingParameterString
+from kart.gui import icons
+
+from .base import KartAlgorithm
+
+
+class RepoPushToRemote(KartAlgorithm):
+    REPO_PATH = "REPO_PATH"
+    REPO_BRANCH_NAME = "REPO_BRANCH_NAME"
+    REPO_REMOTE_NAME = "REPO_REMOTE_NAME"
+
+    def displayName(self):
+        return self.tr("Push Changes to Remote")
+
+    def shortHelpString(self):
+        return self.tr("Sync changes in a repository to a remote location")
+
+    def icon(self):
+        return icons.pushIcon
+
+    def initAlgorithm(self, config=None):
+
+        self.addParameter(
+            QgsProcessingParameterFile(
+                self.REPO_PATH,
+                self.tr("Repo Path"),
+                behavior=QgsProcessingParameterFile.Folder,
+            )
+        )
+
+        self.addParameter(
+            QgsProcessingParameterString(
+                self.REPO_BRANCH_NAME,
+                self.tr("Branch Name"),
+                defaultValue="main",
+            )
+        )
+        self.addParameter(
+            QgsProcessingParameterString(
+                self.REPO_REMOTE_NAME,
+                self.tr("Remote Name"),
+                defaultValue="origin",
+            )
+        )
+
+    def processAlgorithm(self, parameters, context, feedback):
+        from kart.kartapi import Repository
+
+        repo_path = self.parameterAsFile(parameters, self.REPO_PATH, context)
+        branch_name = self.parameterAsString(parameters, self.REPO_BRANCH_NAME, context)
+        remote_name = self.parameterAsString(parameters, self.REPO_REMOTE_NAME, context)
+
+        repo = Repository(repo_path)
+        repo.push(remote_name, branch_name)
+
+        return {
+            self.REPO_PATH: repo_path,
+        }
+
+
+class RepoPullFromRemote(KartAlgorithm):
+    REPO_PATH = "REPO_PATH"
+    REPO_BRANCH_NAME = "REPO_BRANCH_NAME"
+    REPO_REMOTE_NAME = "REPO_REMOTE_NAME"
+
+    def displayName(self):
+        return self.tr("Pull Changes from Remote")
+
+    def shortHelpString(self):
+        return self.tr("Sync changes in a remote location to a local repository")
+
+    def icon(self):
+        return icons.pullIcon
+
+    def initAlgorithm(self, config=None):
+
+        self.addParameter(
+            QgsProcessingParameterFile(
+                self.REPO_PATH,
+                self.tr("Repo Path"),
+                behavior=QgsProcessingParameterFile.Folder,
+            )
+        )
+
+        self.addParameter(
+            QgsProcessingParameterString(
+                self.REPO_BRANCH_NAME,
+                self.tr("Branch Name"),
+                defaultValue="main",
+            )
+        )
+        self.addParameter(
+            QgsProcessingParameterString(
+                self.REPO_REMOTE_NAME,
+                self.tr("Remote Name"),
+                defaultValue="origin",
+            )
+        )
+
+    def processAlgorithm(self, parameters, context, feedback):
+        from kart.kartapi import Repository
+
+        repo_path = self.parameterAsFile(parameters, self.REPO_PATH, context)
+        branch_name = self.parameterAsString(parameters, self.REPO_BRANCH_NAME, context)
+        remote_name = self.parameterAsString(parameters, self.REPO_REMOTE_NAME, context)
+
+        repo = Repository(repo_path)
+        repo.pull(remote_name, branch_name)
+
+        return {
+            self.REPO_PATH: repo_path,
+        }

--- a/kart/processing/repos.py
+++ b/kart/processing/repos.py
@@ -1,0 +1,156 @@
+from qgis.core import (
+    QgsProcessingParameterFile,
+    QgsProcessingParameterBoolean,
+    QgsProcessingParameterNumber,
+    QgsProcessingParameterString,
+    QgsProcessingParameterExtent,
+    QgsProcessingParameterFolderDestination,
+    QgsProcessingOutputMultipleLayers,
+    QgsReferencedRectangle,
+)
+from kart.gui import icons
+
+from .base import KartAlgorithm
+
+
+class RepoInit(KartAlgorithm):
+    REPO_PATH = "REPO_PATH"
+
+    def displayName(self):
+        return self.tr("Create Empty Repo")
+
+    def shortHelpString(self):
+        return self.tr("Create a new empty repository")
+
+    def icon(self):
+        return icons.createRepoIcon
+
+    def initAlgorithm(self, config=None):
+
+        self.addParameter(
+            QgsProcessingParameterFile(
+                self.REPO_PATH,
+                self.tr("Repo Path"),
+                behavior=QgsProcessingParameterFile.Folder,
+            )
+        )
+
+    def processAlgorithm(self, parameters, context, feedback):
+        from kart.kartapi import Repository
+
+        repo_path = self.parameterAsString(parameters, self.REPO_PATH, context)
+
+        repo = Repository(repo_path)
+        repo.init()
+
+        return {self.REPO_PATH: repo_path}
+
+
+class RepoClone(KartAlgorithm):
+    REPO_CLONE_URL = "REPO_CLONE_URL"
+    REPO_CLONE_REFISH = "REPO_CLONE_REFISH"
+    REPO_CLONE_DEPTH = "REPO_CLONE_DEPTH"
+    REPO_CLONE_SPATIAL_EXTENT = "REPO_CLONE_SPATIAL_EXTENT"
+    REPO_OUTPUT_FOLDER = "REPO_OUTPUT_FOLDER"
+    REPO_ADD_TO_MAP = "REPO_ADD_TO_MAP"
+    REPO_OUTPUT_LAYERS = "REPO_OUTPUT_LAYERS"
+
+    def displayName(self):
+        return self.tr("Clone Repo")
+
+    def shortHelpString(self):
+        return self.tr("Clones a repository to a folder")
+
+    def icon(self):
+        return icons.cloneRepoIcon
+
+    def initAlgorithm(self, config=None):
+
+        self.addParameter(
+            QgsProcessingParameterString(
+                self.REPO_CLONE_URL,
+                self.tr("Repo URL"),
+            )
+        )
+
+        self.addParameter(
+            QgsProcessingParameterString(
+                self.REPO_CLONE_REFISH,
+                self.tr("Branch/Tag/Ref"),
+                optional=True,
+            )
+        )
+
+        self.addParameter(
+            QgsProcessingParameterExtent(
+                self.REPO_CLONE_SPATIAL_EXTENT,
+                self.tr("Spatial Extent"),
+                optional=True,
+            )
+        )
+
+        self.addParameter(
+            QgsProcessingParameterNumber(
+                self.REPO_CLONE_DEPTH,
+                self.tr("Depth"),
+                type=QgsProcessingParameterNumber.Integer,
+                optional=True,
+                minValue=1,
+            )
+        )
+
+        self.addParameter(
+            QgsProcessingParameterFolderDestination(
+                self.REPO_OUTPUT_FOLDER, self.tr("Output folder")
+            )
+        )
+
+        self.addParameter(
+            QgsProcessingParameterBoolean(
+                self.REPO_ADD_TO_MAP, self.tr("Add layers to the Map")
+            )
+        )
+
+        self.addOutput(
+            QgsProcessingOutputMultipleLayers(
+                self.REPO_OUTPUT_LAYERS,
+                self.tr("Output Layers"),
+            )
+        )
+
+    def processAlgorithm(self, parameters, context, feedback):
+        from kart.kartapi import Repository
+
+        repo_url = self.parameterAsString(parameters, self.REPO_CLONE_URL, context)
+        folder = self.parameterAsFile(parameters, self.REPO_OUTPUT_FOLDER, context)
+        refish = self.parameterAsString(parameters, self.REPO_CLONE_REFISH, context)
+        depth = self.parameterAsInt(parameters, self.REPO_CLONE_DEPTH, context)
+        add_layers = self.parameterAsBool(parameters, self.REPO_ADD_TO_MAP, context)
+
+        extent_rect = self.parameterAsExtent(parameters, self.REPO_CLONE_DEPTH, context)
+        extent_crs = self.parameterAsExtentCrs(
+            parameters, self.REPO_CLONE_SPATIAL_EXTENT, context
+        )
+        extent = None
+        if parameters.get(self.REPO_CLONE_SPATIAL_EXTENT):
+            extent = QgsReferencedRectangle(extent_rect, extent_crs)
+
+        repo = Repository.clone(repo_url, folder, extent=extent, depth=depth or None)
+        if refish:
+            repo.checkoutBranch(refish)
+
+        layers = []
+        vector_datasets, table_datasets = repo.datasets()
+        for dataset in vector_datasets:
+            layers.append(repo.workingCopyLayer(dataset))
+        for dataset in table_datasets:
+            layers.append(repo.workingCopyLayer(dataset))
+
+        if add_layers:
+            for layer in layers:
+                context.context.addLayerToLoadOnCompletion(layer)
+
+        return {
+            self.REPO_OUTPUT_FOLDER: folder,
+            self.REPO_OUTPUT_LAYERS: layers,
+        }

--- a/kart/processing/repos.py
+++ b/kart/processing/repos.py
@@ -1,4 +1,5 @@
 from qgis.core import (
+    QgsProcessingContext,
     QgsProcessingParameterFile,
     QgsProcessingParameterBoolean,
     QgsProcessingParameterNumber,
@@ -148,7 +149,9 @@ class RepoClone(KartAlgorithm):
 
         if add_layers:
             for layer in layers:
-                context.context.addLayerToLoadOnCompletion(layer)
+                context.addLayerToLoadOnCompletion(
+                    layer.id(), QgsProcessingContext.LayerDetails()
+                )
 
         return {
             self.REPO_OUTPUT_FOLDER: folder,

--- a/kart/processing/tags.py
+++ b/kart/processing/tags.py
@@ -1,0 +1,49 @@
+from qgis.core import QgsProcessingParameterFile, QgsProcessingParameterString
+from kart.gui import icons
+
+from .base import KartAlgorithm
+
+
+class RepoCreateTag(KartAlgorithm):
+    REPO_PATH = "REPO_PATH"
+    REPO_TAG_NAME = "REPO_TAG_NAME"
+
+    def displayName(self):
+        return self.tr("Create Tag")
+
+    def shortHelpString(self):
+        return self.tr("Create a new tag")
+
+    def icon(self):
+        return icons.propertiesIcon
+
+    def initAlgorithm(self, config=None):
+
+        self.addParameter(
+            QgsProcessingParameterFile(
+                self.REPO_PATH,
+                self.tr("Repo Path"),
+                behavior=QgsProcessingParameterFile.Folder,
+            )
+        )
+
+        self.addParameter(
+            QgsProcessingParameterString(
+                self.REPO_TAG_NAME,
+                self.tr("Tag Name"),
+            )
+        )
+
+    def processAlgorithm(self, parameters, context, feedback):
+        from kart.kartapi import Repository
+
+        repo_path = self.parameterAsFile(parameters, self.REPO_PATH, context)
+        tag_name = self.parameterAsString(parameters, self.REPO_TAG_NAME, context)
+
+        repo = Repository(repo_path)
+        repo.createTag(tag_name)
+
+        return {
+            self.REPO_PATH: repo_path,
+            self.REPO_TAG_NAME: tag_name,
+        }


### PR DESCRIPTION
Adds a number of Kart tools to the QGIS processing toolbox to allow automation of some common data version control tasks. Initially this supports:

  * Creating empty repositories
  * Cloning repositories by URL
  * Creating & deleting, and switching between branches
  * Create tags
  * Importing / update single vector datasets
  * Pulling and pushing changes to/from remotes

<img width="464" alt="Screenshot 2024-08-14 at 10 47 01 PM" src="https://github.com/user-attachments/assets/70526c38-b488-48bd-9ec1-baa49dbcbfdb">
