### PR TITLE
Fix crash of swipe tool

### DIFF
--- a/kart/gui/mapswipetool.py
+++ b/kart/gui/mapswipetool.py
@@ -35,8 +35,8 @@ class MapSwipeTool(QgsMapTool):
         self.setLayersSwipe()
         self.swipe.setIsVertical(True)
         self.swipe.setLength(
-            self.swipe.boundingRect().width() / 2,
-            self.swipe.boundingRect().height() / 2,
+            int(self.swipe.boundingRect().width() / 2),
+            int(self.swipe.boundingRect().height() / 2),
         )
 
     def deactivate(self):


### PR DESCRIPTION
QLine does not accept floats anymore nowadays, which lead to a crash in

https://github.com/koordinates/kart-qgis-plugin/blob/b0fa22c878380c29b13e8f9bc4c16c9f320df36d/kart/gui/swipemap.py#L39

Fixes https://github.com/koordinates/kart-qgis-plugin/issues/110