### PR TITLE
Set current Kart to 0.15.3

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -21,7 +21,7 @@ jobs:
 
     env:
       QGIS_TEST_VERSION: ${{ matrix.qgis_version }}
-      KART_VERSION: "0.15.2"
+      KART_VERSION: "0.15.3"
 
     steps:
       - name: Checkout

--- a/kart/kartapi.py
+++ b/kart/kartapi.py
@@ -37,7 +37,7 @@ from kart import logging
 
 
 MINIMUM_SUPPORTED_VERSION = "0.14.0"
-CURRENT_VERSION = "0.15.0"
+CURRENT_VERSION = "0.15.3"
 
 
 class KartException(Exception):


### PR DESCRIPTION
There are no critical changes in Kart require for for the plugin, but it has been a while since the patch version was bumped. Supported Kart version remains `0.14.0`.