### PR TITLE
Compatibility with Qt6 (QGIS 4)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: "3.7"
+          python-version: "3.9"
 
       - name: Build package
         run: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v1
         with:
-          python-version: "3.7"
+          python-version: "3.9"
 
       - name: flake8 Lint
         uses: py-actions/flake8@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: "3.7"
+          python-version: "3.9"
 
       - name: Build package
         run: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,7 +73,7 @@ python helper.py package
 
 - QGIS 3.16+
 - Kart 0.15.3 installed separately (minimum supported: 0.14.0)
-- Compatible with Python 3.7+
+- Compatible with Python 3.9+
 
 ## Testing Notes
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,6 +46,6 @@ We use [Black](https://github.com/psf/black) to ensure consistent code formattin
 * Sublime Text: install [sublack](https://packagecontrol.io/packages/sublack) via Package Control
 * VSCode [instructions](https://code.visualstudio.com/docs/python/editing#_formatting)
 
-We use the default settings, and target python 3.7+.
+We use the default settings, and target python 3.9+.
 
 One easy solution is to install [pre-commit](https://pre-commit.com), run `pre-commit install --install-hooks` and it'll automatically validate your changes code as a git pre-commit hook.

--- a/kart/gui/clonedialog.py
+++ b/kart/gui/clonedialog.py
@@ -24,7 +24,7 @@ class CloneDialog(BASE, WIDGET):
         self.setupUi(self)
 
         self.bar = QgsMessageBar()
-        self.bar.setSizePolicy(QSizePolicy.Minimum, QSizePolicy.Fixed)
+        self.bar.setSizePolicy(QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Fixed)
         self.layout().addWidget(self.bar)
 
         self.btnBrowseSrc.clicked.connect(lambda: self.browse(self.txtSrc))
@@ -55,7 +55,7 @@ class CloneDialog(BASE, WIDGET):
 
         self.show()
         self.raise_()
-        self.setWindowState(self.windowState() & ~Qt.WindowMinimized)
+        self.setWindowState(self.windowState() & ~Qt.WindowState.WindowMinimized)
         self.activateWindow()
 
     def okClicked(self):
@@ -63,7 +63,7 @@ class CloneDialog(BASE, WIDGET):
             self.location = self.locationPanel.location()
         except InvalidLocationException:
             self.bar.pushMessage(
-                "Invalid location definition", Qgis.Warning, duration=5
+                "Invalid location definition", Qgis.MessageLevel.Warning, duration=5
             )
             return
         self.src = self.txtSrc.text()
@@ -71,7 +71,9 @@ class CloneDialog(BASE, WIDGET):
         if self.grpFilter.isChecked():
             self.extent = self.extentPanel.getExtent()
             if self.extent is None:
-                self.bar.pushMessage("Invalid extent value", Qgis.Warning, duration=5)
+                self.bar.pushMessage(
+                    "Invalid extent value", Qgis.MessageLevel.Warning, duration=5
+                )
                 return
         else:
             self.extent = None
@@ -83,5 +85,5 @@ class CloneDialog(BASE, WIDGET):
             self.accept()
         else:
             self.bar.pushMessage(
-                "Text fields must not be empty", Qgis.Warning, duration=5
+                "Text fields must not be empty", Qgis.MessageLevel.Warning, duration=5
             )

--- a/kart/gui/conflictsdialog.py
+++ b/kart/gui/conflictsdialog.py
@@ -33,7 +33,7 @@ class ConflictsDialog(BASE, WIDGET):
         self.setupUi(self)
 
         self.bar = QgsMessageBar()
-        self.bar.setSizePolicy(QSizePolicy.Minimum, QSizePolicy.Fixed)
+        self.bar.setSizePolicy(QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Fixed)
         self.layout().addWidget(self.bar)
 
         self.resize(1024, 768)
@@ -120,10 +120,10 @@ class ConflictsDialog(BASE, WIDGET):
             self,
             "Solve conflicts",
             "Are you sure you want to solve all conflicts using the 'ours' version?",
-            QMessageBox.Yes | QMessageBox.No,
-            QMessageBox.Yes,
+            QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
+            QMessageBox.StandardButton.Yes,
         )
-        if ret == QMessageBox.Yes:
+        if ret == QMessageBox.StandardButton.Yes:
             pass
 
     def solveAllTheirs(self):
@@ -131,10 +131,10 @@ class ConflictsDialog(BASE, WIDGET):
             self,
             "Solve conflicts",
             "Are you sure you want to solve all conflicts using the 'theirs' version?",
-            QMessageBox.Yes | QMessageBox.No,
-            QMessageBox.Yes,
+            QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
+            QMessageBox.StandardButton.Yes,
         )
-        if ret == QMessageBox.Yes:
+        if ret == QMessageBox.StandardButton.Yes:
             pass
 
     def solveFeature(self):
@@ -152,7 +152,9 @@ class ConflictsDialog(BASE, WIDGET):
                 feature["properties"][attrib] = finalItem.value
             else:
                 self.bar.pushMessage(
-                    "", "There are still conflicts in the current feature", Qgis.Warning
+                    "",
+                    "There are still conflicts in the current feature",
+                    Qgis.MessageLevel.Warning,
                 )
                 return
         if hasGeom:
@@ -161,7 +163,9 @@ class ConflictsDialog(BASE, WIDGET):
                 feature["geometry"] = geomItem.value
             else:
                 self.bar.pushMessage(
-                    "", "There are still conflicts in the current feature", Qgis.Warning
+                    "",
+                    "There are still conflicts in the current feature",
+                    Qgis.MessageLevel.Warning,
                 )
                 return
         feature[
@@ -181,8 +185,8 @@ class ConflictsDialog(BASE, WIDGET):
                     self,
                     "Solve conflicts",
                     "All conflicts are solved. The merge operation will now be closed",
-                    QMessageBox.Ok,
-                    QMessageBox.Ok,
+                    QMessageBox.StandardButton.Ok,
+                    QMessageBox.StandardButton.Ok,
                 )
                 self.okToMerge = True
                 self.close()
@@ -282,9 +286,9 @@ class ConflictsDialog(BASE, WIDGET):
         self.tableAttributes.resizeColumnsToContents()
         header = self.tableAttributes.horizontalHeader()
         for column in range(header.count()):
-            header.setSectionResizeMode(column, QHeaderView.Fixed)
+            header.setSectionResizeMode(column, QHeaderView.ResizeMode.Fixed)
             width = header.sectionSize(column)
-            header.setSectionResizeMode(column, QHeaderView.Interactive)
+            header.setSectionResizeMode(column, QHeaderView.ResizeMode.Interactive)
             header.resizeSection(column, min(150, width))
 
     def closeEvent(self, evnt):
@@ -293,9 +297,9 @@ class ConflictsDialog(BASE, WIDGET):
                 self,
                 "Conflict resolution",
                 "Do you really want to exit without resolving conflicts?",
-                QMessageBox.Yes | QMessageBox.No,
+                QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
             )
-            if ret == QMessageBox.No:
+            if ret == QMessageBox.StandardButton.No:
                 evnt.ignore()
             else:
                 self.resolvedFeatures = None
@@ -307,9 +311,9 @@ class ValueItem(QTableWidgetItem):
         self.value = value
 
         if conflicted:
-            self.setBackground(Qt.yellow)
+            self.setBackground(Qt.GlobalColor.yellow)
         else:
-            self.setBackground(Qt.white)
+            self.setBackground(Qt.GlobalColor.white)
 
         if isinstance(value, dict):
             s = value["type"]
@@ -317,7 +321,7 @@ class ValueItem(QTableWidgetItem):
             s = str(value)
 
         self.setText(s)
-        self.setFlags(Qt.ItemIsEnabled)
+        self.setFlags(Qt.ItemFlag.ItemIsEnabled)
 
 
 class FinalValueItem(QTableWidgetItem):
@@ -327,7 +331,7 @@ class FinalValueItem(QTableWidgetItem):
         self.value = None
 
         self.setText("")
-        self.setBackground(Qt.yellow)
+        self.setBackground(Qt.GlobalColor.yellow)
 
     def setValue(self, value):
         self.value = value
@@ -338,7 +342,7 @@ class FinalValueItem(QTableWidgetItem):
         else:
             s = str(value)
         self.setText(s)
-        self.setBackground(Qt.white)
+        self.setBackground(Qt.GlobalColor.white)
 
 
 class ConflictItem(QTreeWidgetItem):

--- a/kart/gui/dbconnectiondialog.py
+++ b/kart/gui/dbconnectiondialog.py
@@ -27,7 +27,7 @@ class DbConnectionDialog(BASE, WIDGET):
         self.setupUi(self)
 
         self.bar = QgsMessageBar()
-        self.bar.setSizePolicy(QSizePolicy.Minimum, QSizePolicy.Fixed)
+        self.bar.setSizePolicy(QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Fixed)
         self.layout().addWidget(self.bar, 10, 0, 1, 3)
 
         self.authWidget = QgsAuthSettingsWidget()
@@ -61,7 +61,7 @@ class DbConnectionDialog(BASE, WIDGET):
         except Exception:
             self.bar.pushMessage(
                 "Cannot connect to the provided database table(s)",
-                Qgis.Warning,
+                Qgis.MessageLevel.Warning,
                 duration=5,
             )
             return
@@ -69,7 +69,9 @@ class DbConnectionDialog(BASE, WIDGET):
             table = table.replace(".", "/")
             self.comboTable.addItem(table, table)
         self.bar.pushMessage(
-            "Tables correctly loaded into tables list", Qgis.Success, duration=5
+            "Tables correctly loaded into tables list",
+            Qgis.MessageLevel.Success,
+            duration=5,
         )
 
     def okClicked(self):
@@ -79,7 +81,7 @@ class DbConnectionDialog(BASE, WIDGET):
         except Exception:
             self.bar.pushMessage(
                 "Cannot connect to the provided database table(s)",
-                Qgis.Warning,
+                Qgis.MessageLevel.Warning,
                 duration=5,
             )
             return

--- a/kart/gui/diffviewer.py
+++ b/kart/gui/diffviewer.py
@@ -67,11 +67,11 @@ WIDGET, BASE = uic.loadUiType(
 class DiffViewerDialog(QDialog):
     def __init__(self, parent, diff, repo, showRecoverNewButton=True):
         super(QDialog, self).__init__(parent)
-        self.setWindowFlags(Qt.Window)
+        self.setWindowFlags(Qt.WindowType.Window)
         layout = QVBoxLayout()
         layout.setMargin(0)
         self.bar = QgsMessageBar()
-        self.bar.setSizePolicy(QSizePolicy.Minimum, QSizePolicy.Fixed)
+        self.bar.setSizePolicy(QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Fixed)
         layout.addWidget(self.bar)
         self.history = DiffViewerWidget(diff, repo, showRecoverNewButton)
         self.history.workingLayerChanged.connect(self.workingLayerChanged)
@@ -81,7 +81,9 @@ class DiffViewerDialog(QDialog):
         self.setWindowTitle("Diff viewer")
 
     def workingLayerChanged(self):
-        self.bar.pushMessage("Diff", "Working copy has been updated", Qgis.Success, 5)
+        self.bar.pushMessage(
+            "Diff", "Working copy has been updated", Qgis.MessageLevel.Success, 5
+        )
 
     def closeEvent(self, evt):
         self.history.removeMapLayers()
@@ -112,10 +114,10 @@ class DiffViewerWidget(WIDGET, BASE):
 
         self.setupUi(self)
 
-        self.setWindowFlags(self.windowFlags() | Qt.WindowSystemMenuHint)
+        self.setWindowFlags(self.windowFlags() | Qt.WindowType.WindowSystemMenuHint)
 
         self.canvas = QgsMapCanvas(self.canvasWidget)
-        self.canvas.setCanvasColor(Qt.white)
+        self.canvas.setCanvasColor(Qt.GlobalColor.white)
         self.canvas.enableAntiAliasing(True)
         tabLayout = QVBoxLayout()
         tabLayout.setMargin(0)
@@ -157,7 +159,7 @@ class DiffViewerWidget(WIDGET, BASE):
             return ref["geometry"] is not None
         else:
             oldLayer, newLayer = self.layerDiffLayers[item.dataset]
-            return oldLayer.wkbType() != QgsWkbTypes.NoGeometry
+            return oldLayer.wkbType() != QgsWkbTypes.Type.NoGeometry
 
     def treeItemChanged(self, current, previous):
         self.grpTransparency.setVisible(True)
@@ -218,7 +220,12 @@ class DiffViewerWidget(WIDGET, BASE):
         fields.extend(old.get("properties", {}).keys())
         fields = list(set(fields))
 
-        changeTypeColor = [Qt.green, QColor(255, 170, 0), Qt.red, Qt.white]
+        changeTypeColor = [
+            Qt.GlobalColor.green,
+            QColor(255, 170, 0),
+            Qt.GlobalColor.red,
+            Qt.GlobalColor.white,
+        ]
         changeTypeName = ["Added", "Modified", "Removed", "Unchanged"]
         self.attributesTable.clear()
         self.attributesTable.verticalHeader().show()
@@ -286,10 +293,10 @@ class DiffViewerWidget(WIDGET, BASE):
         self.attributesTable.resizeColumnsToContents()
         header = self.attributesTable.horizontalHeader()
         for column in range(header.count()):
-            header.setSectionResizeMode(column, QHeaderView.Fixed)
+            header.setSectionResizeMode(column, QHeaderView.ResizeMode.Fixed)
             width = header.sectionSize(column)
             header.resizeSection(column, width)
-            header.setSectionResizeMode(column, QHeaderView.Interactive)
+            header.setSectionResizeMode(column, QHeaderView.ResizeMode.Interactive)
 
     def fillTree(self):
         self.featuresTree.clear()

--- a/kart/gui/dockwidget.py
+++ b/kart/gui/dockwidget.py
@@ -66,11 +66,11 @@ class KartDockWidget(BASE, WIDGET):
         super(QDockWidget, self).__init__(iface.mainWindow())
         self.setupUi(self)
 
-        self.tree.setFocusPolicy(Qt.NoFocus)
-        self.tree.setContextMenuPolicy(Qt.CustomContextMenu)
-        self.tree.setSelectionBehavior(QAbstractItemView.SelectRows)
+        self.tree.setFocusPolicy(Qt.FocusPolicy.NoFocus)
+        self.tree.setContextMenuPolicy(Qt.ContextMenuPolicy.CustomContextMenu)
+        self.tree.setSelectionBehavior(QAbstractItemView.SelectionBehavior.SelectRows)
         self.tree.customContextMenuRequested.connect(self.showPopupMenu)
-        self.tree.setDragDropMode(QAbstractItemView.DragDrop)
+        self.tree.setDragDropMode(QAbstractItemView.DragDropMode.DragDrop)
 
         def onItemExpanded(item):
             if hasattr(item, "onExpanded"):
@@ -84,7 +84,7 @@ class KartDockWidget(BASE, WIDGET):
         def mimeData(items):
             mimeData = QMimeData()
             encodedData = QByteArray()
-            stream = QDataStream(encodedData, QIODevice.WriteOnly)
+            stream = QDataStream(encodedData, QIODevice.OpenModeFlag.WriteOnly)
 
             for item in items:
                 if isinstance(item, DatasetItem):
@@ -164,7 +164,7 @@ class ReposItem(RefreshableItem):
 
         self.setText(0, "Repositories")
         self.setIcon(0, icons.repoIcon)
-        self.setChildIndicatorPolicy(QTreeWidgetItem.ShowIndicator)
+        self.setChildIndicatorPolicy(QTreeWidgetItem.ChildIndicatorPolicy.ShowIndicator)
 
         self.populate()
 
@@ -196,7 +196,7 @@ class ReposItem(RefreshableItem):
                 iface.messageBar().pushMessage(
                     "Error",
                     "The selected folder is not a Kart repository",
-                    level=Qgis.Warning,
+                    level=Qgis.MessageLevel.Warning,
                 )
 
     @executeskart
@@ -207,7 +207,9 @@ class ReposItem(RefreshableItem):
             if os.path.exists(dialog.folder):
                 if any(os.scandir(dialog.folder)):
                     iface.messageBar().pushMessage(
-                        "Error", "The specified folder is not empty", level=Qgis.Warning
+                        "Error",
+                        "The specified folder is not empty",
+                        level=Qgis.MessageLevel.Warning,
                     )
                     return
             else:
@@ -217,7 +219,7 @@ class ReposItem(RefreshableItem):
                     iface.messageBar().pushMessage(
                         "Error",
                         "Could not create the specified folder",
-                        level=Qgis.Warning,
+                        level=Qgis.MessageLevel.Warning,
                     )
                     return
             repo = Repository(dialog.folder)
@@ -226,7 +228,9 @@ class ReposItem(RefreshableItem):
                 RepoManager.instance().add_repo(repo)
             else:
                 iface.messageBar().pushMessage(
-                    "Error", "Could not initialize repository", level=Qgis.Warning
+                    "Error",
+                    "Could not initialize repository",
+                    level=Qgis.MessageLevel.Warning,
                 )
 
     @executeskart
@@ -253,7 +257,7 @@ class ReposItem(RefreshableItem):
 
         dialog = CloneDialog()
         dialog.show()
-        ret = dialog.exec_()
+        ret = dialog.exec()
         if ret == dialog.Accepted:
             with progressBar("Clone") as bar:
                 bar.setText("Cloning repository")
@@ -283,7 +287,7 @@ class RepoItem(RefreshableItem):
 
         self.setTitle()
         self.setIcon(0, icons.repoIcon)
-        self.setChildIndicatorPolicy(QTreeWidgetItem.ShowIndicator)
+        self.setChildIndicatorPolicy(QTreeWidgetItem.ChildIndicatorPolicy.ShowIndicator)
 
     def refreshContent(self):
         self.takeChildren()
@@ -412,7 +416,7 @@ class RepoItem(RefreshableItem):
             iface.messageBar().pushMessage(
                 "Import",
                 "The selected file is not a valid vector layer",
-                level=Qgis.Warning,
+                level=Qgis.MessageLevel.Warning,
             )
             return
         tmpfolder = tempfile.TemporaryDirectory()
@@ -421,11 +425,11 @@ class RepoItem(RefreshableItem):
         ret = QgsVectorFileWriter.writeAsVectorFormat(
             layer, filenameToImport, "utf-8", layer.crs()
         )
-        if ret[0] != QgsVectorFileWriter.NoError:
+        if ret[0] != QgsVectorFileWriter.WriterError.NoError:
             iface.messageBar().pushMessage(
                 "Import",
                 "Could not convert the selected layer to a gpkg file",
-                level=Qgis.Warning,
+                level=Qgis.MessageLevel.Warning,
             )
         else:
             self._importIntoRepo(filenameToImport)
@@ -435,7 +439,7 @@ class RepoItem(RefreshableItem):
     def _importIntoRepo(self, source):
         self.repo.importIntoRepo(source)
         iface.messageBar().pushMessage(
-            "Import", "Layer correctly imported", level=Qgis.Info
+            "Import", "Layer correctly imported", level=Qgis.MessageLevel.Info
         )
         if self.populated:
             self.datasetsItem.refreshContent()
@@ -445,7 +449,7 @@ class RepoItem(RefreshableItem):
     def commitChanges(self):
         if self.repo.isWorkingTreeClean():
             iface.messageBar().pushMessage(
-                "Commit", "Nothing to commit", level=Qgis.Warning
+                "Commit", "Nothing to commit", level=Qgis.MessageLevel.Warning
             )
         else:
             msg, ok = QInputDialog.getMultiLineText(
@@ -454,11 +458,15 @@ class RepoItem(RefreshableItem):
             if ok and msg:
                 if self.repo.commit(msg):
                     iface.messageBar().pushMessage(
-                        "Commit", "Changes correctly committed", level=Qgis.Info
+                        "Commit",
+                        "Changes correctly committed",
+                        level=Qgis.MessageLevel.Info,
                     )
                 else:
                     iface.messageBar().pushMessage(
-                        "Commit", "Changes could not be commited", level=Qgis.Warning
+                        "Commit",
+                        "Changes could not be commited",
+                        level=Qgis.MessageLevel.Warning,
                     )
 
     @executeskart
@@ -468,7 +476,7 @@ class RepoItem(RefreshableItem):
             iface.messageBar().pushMessage(
                 "Changes",
                 "There are schema changes in the working copy and changes cannot be shown",
-                level=Qgis.Warning,
+                level=Qgis.MessageLevel.Warning,
             )
             return
         diff = self.repo.diff()
@@ -482,7 +490,7 @@ class RepoItem(RefreshableItem):
             iface.messageBar().pushMessage(
                 "Changes",
                 "There are no changes in the working copy",
-                level=Qgis.Warning,
+                level=Qgis.MessageLevel.Warning,
             )
 
     @executeskart
@@ -509,7 +517,7 @@ class RepoItem(RefreshableItem):
                 )
             else:
                 iface.messageBar().pushMessage(
-                    "Merge", "Branch correctly merged", level=Qgis.Info
+                    "Merge", "Branch correctly merged", level=Qgis.MessageLevel.Info
                 )
 
     @executeskart
@@ -519,7 +527,7 @@ class RepoItem(RefreshableItem):
             iface.messageBar().pushMessage(
                 "Discard changes",
                 "Working copy changes have been discarded",
-                level=Qgis.Info,
+                level=Qgis.MessageLevel.Info,
             )
 
     @executeskart
@@ -528,21 +536,23 @@ class RepoItem(RefreshableItem):
             iface.messageBar().pushMessage(
                 "Merge",
                 "Cannot continue. There are merge conflicts.",
-                level=Qgis.Warning,
+                level=Qgis.MessageLevel.Warning,
             )
         else:
             self.repo.continueMerge()
             iface.messageBar().pushMessage(
                 "Merge",
                 "Merge operation was correctly continued and closed",
-                level=Qgis.Info,
+                level=Qgis.MessageLevel.Info,
             )
 
     @executeskart
     def abortMerge(self):
         self.repo.abortMerge()
         iface.messageBar().pushMessage(
-            "Merge", "Merge operation was correctly aborted", level=Qgis.Info
+            "Merge",
+            "Merge operation was correctly aborted",
+            level=Qgis.MessageLevel.Info,
         )
 
     @executeskart
@@ -552,7 +562,7 @@ class RepoItem(RefreshableItem):
                 "Resolve",
                 "Conflicts involve schema changes and cannot be resolved "
                 "using the plugin interface",
-                level=Qgis.Warning,
+                level=Qgis.MessageLevel.Warning,
             )
             return
         conflicts = self.repo.conflicts()
@@ -565,11 +575,13 @@ class RepoItem(RefreshableItem):
                 iface.messageBar().pushMessage(
                     "Merge",
                     "Merge operation was correctly continued and closed",
-                    level=Qgis.Info,
+                    level=Qgis.MessageLevel.Info,
                 )
         else:
             iface.messageBar().pushMessage(
-                "Resolve", "There are no conflicts to resolve", level=Qgis.Warning
+                "Resolve",
+                "There are no conflicts to resolve",
+                level=Qgis.MessageLevel.Warning,
             )
 
     @executeskart
@@ -585,7 +597,7 @@ class RepoItem(RefreshableItem):
                     if dialog.pushAll
                     else f"{dialog.remote}/{dialog.branch}"
                 ),
-                level=Qgis.Info,
+                level=Qgis.MessageLevel.Info,
             )
 
     @executeskart
@@ -603,7 +615,7 @@ class RepoItem(RefreshableItem):
                 )
             else:
                 iface.messageBar().pushMessage(
-                    "Pull", "Pull correctly performed", level=Qgis.Info
+                    "Pull", "Pull correctly performed", level=Qgis.MessageLevel.Info
                 )
 
     @executeskart
@@ -619,7 +631,7 @@ class RepoItem(RefreshableItem):
             iface.messageBar().pushMessage(
                 "Apply patch",
                 "Patch was correctly applied to working copy",
-                level=Qgis.Info,
+                level=Qgis.MessageLevel.Info,
             )
 
 
@@ -692,7 +704,7 @@ class DatasetItem(QTreeWidgetItem):
         changes = self.repo.changes().get(self.name)
         if changes is None:
             iface.messageBar().pushMessage(
-                "Commit", "Nothing to commit", level=Qgis.Warning
+                "Commit", "Nothing to commit", level=Qgis.MessageLevel.Warning
             )
         else:
             msg, ok = QInputDialog.getMultiLineText(
@@ -701,11 +713,15 @@ class DatasetItem(QTreeWidgetItem):
             if ok and msg:
                 if self.repo.commit(msg, dataset=self.name):
                     iface.messageBar().pushMessage(
-                        "Commit", "Changes correctly committed", level=Qgis.Info
+                        "Commit",
+                        "Changes correctly committed",
+                        level=Qgis.MessageLevel.Info,
                     )
                 else:
                     iface.messageBar().pushMessage(
-                        "Commit", "Changes could not be commited", level=Qgis.Warning
+                        "Commit",
+                        "Changes could not be commited",
+                        level=Qgis.MessageLevel.Warning,
                     )
 
     @executeskart
@@ -715,7 +731,7 @@ class DatasetItem(QTreeWidgetItem):
             iface.messageBar().pushMessage(
                 "Changes",
                 "There are schema changes in the working copy and changes cannot be shown",
-                level=Qgis.Warning,
+                level=Qgis.MessageLevel.Warning,
             )
             return
         diff = self.repo.diff(dataset=self.name)
@@ -728,7 +744,7 @@ class DatasetItem(QTreeWidgetItem):
             iface.messageBar().pushMessage(
                 "Changes",
                 "There are no changes in the working copy for this dataset",
-                level=Qgis.Warning,
+                level=Qgis.MessageLevel.Warning,
             )
 
     @executeskart
@@ -740,7 +756,7 @@ class DatasetItem(QTreeWidgetItem):
             iface.messageBar().pushMessage(
                 "Discard changes",
                 "Working copy changes have been discarded",
-                level=Qgis.Info,
+                level=Qgis.MessageLevel.Info,
             )
 
     @executeskart
@@ -754,7 +770,7 @@ class DatasetItem(QTreeWidgetItem):
             iface.messageBar().pushMessage(
                 "Add layer",
                 "Dataset could not be added",
-                level=Qgis.Warning,
+                level=Qgis.MessageLevel.Warning,
             )
         else:
             QgsProject.instance().addMapLayer(layer)
@@ -766,7 +782,7 @@ class DatasetItem(QTreeWidgetItem):
                 "Remove dataset",
                 "There are pending changes in the working copy. "
                 "Commit them before deleting this dataset",
-                level=Qgis.Warning,
+                level=Qgis.MessageLevel.Warning,
             )
             return
         source = self.repo.workingCopyLayer(self.name).source()
@@ -784,14 +800,17 @@ class DatasetItem(QTreeWidgetItem):
             )
 
         ret = QMessageBox.warning(
-            iface.mainWindow(), "Remove dataset", msg, QMessageBox.Yes | QMessageBox.No
+            iface.mainWindow(),
+            "Remove dataset",
+            msg,
+            QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
         )
-        if ret == QMessageBox.Yes:
+        if ret == QMessageBox.StandardButton.Yes:
             self.repo.deleteDataset(self.name)
             iface.messageBar().pushMessage(
                 "Remove dataset",
                 "Dataset correctly removed",
-                level=Qgis.Info,
+                level=Qgis.MessageLevel.Info,
             )
             self.parent().refreshContent()
             if layer:

--- a/kart/gui/dockwidget.py
+++ b/kart/gui/dockwidget.py
@@ -16,6 +16,7 @@ from qgis.PyQt.QtWidgets import (
     QMenu,
     QInputDialog,
     QMessageBox,
+    QDialog,
 )
 
 from qgis.utils import iface
@@ -203,7 +204,7 @@ class ReposItem(RefreshableItem):
     def createRepo(self):
         dialog = InitDialog()
         ret = dialog.exec()
-        if ret == dialog.Accepted:
+        if ret == QDialog.DialogCode.Accepted:
             if os.path.exists(dialog.folder):
                 if any(os.scandir(dialog.folder)):
                     iface.messageBar().pushMessage(
@@ -258,7 +259,7 @@ class ReposItem(RefreshableItem):
         dialog = CloneDialog()
         dialog.show()
         ret = dialog.exec()
-        if ret == dialog.Accepted:
+        if ret == QDialog.DialogCode.Accepted:
             with progressBar("Clone") as bar:
                 bar.setText("Cloning repository")
                 repo = Repository.clone(
@@ -396,7 +397,7 @@ class RepoItem(RefreshableItem):
     def importLayerFromDatabase(self):
         dlg = DbConnectionDialog()
         ret = dlg.exec()
-        if ret == dlg.Accepted:
+        if ret == QDialog.DialogCode.Accepted:
             self._importIntoRepo(dlg.url)
 
     def importLayerFromFile(self):
@@ -496,14 +497,14 @@ class RepoItem(RefreshableItem):
     @executeskart
     def switchBranch(self):
         dialog = SwitchDialog(self.repo)
-        if dialog.exec() == dialog.Accepted:
+        if dialog.exec() == QDialog.DialogCode.Accepted:
             self.repo.checkoutBranch(dialog.branch, dialog.force)
             self.setTitle()
 
     @executeskart
     def mergeBranch(self):
         dialog = MergeDialog(self.repo)
-        if dialog.exec() == dialog.Accepted:
+        if dialog.exec() == QDialog.DialogCode.Accepted:
             conflicts = self.repo.mergeBranch(
                 dialog.ref, msg=dialog.message, noff=dialog.noff, ffonly=dialog.ffonly
             )
@@ -587,7 +588,7 @@ class RepoItem(RefreshableItem):
     @executeskart
     def push(self):
         dialog = PushDialog(self.repo)
-        if dialog.exec() == dialog.Accepted:
+        if dialog.exec() == QDialog.DialogCode.Accepted:
             self.repo.push(dialog.remote, dialog.branch, dialog.pushAll)
             iface.messageBar().pushMessage(
                 "Push",
@@ -603,7 +604,7 @@ class RepoItem(RefreshableItem):
     @executeskart
     def pull(self):
         dialog = PullDialog(self.repo)
-        if dialog.exec() == dialog.Accepted:
+        if dialog.exec() == QDialog.DialogCode.Accepted:
             ret = self.repo.pull(dialog.remote, dialog.branch)
             if not ret:
                 QMessageBox.warning(

--- a/kart/gui/extentselectionpanel.py
+++ b/kart/gui/extentselectionpanel.py
@@ -54,11 +54,11 @@ class ExtentSelectionPanel(BASE, WIDGET):
         useLayerExtentAction.triggered.connect(self.useLayerExtent)
         useCanvasExtentAction.triggered.connect(self.useCanvasExtent)
 
-        popupmenu.exec_(QCursor.pos())
+        popupmenu.exec(QCursor.pos())
 
     def useLayerExtent(self):
         dlg = LayerSelectionDialog(self)
-        if dlg.exec_():
+        if dlg.exec():
             layer = dlg.selected_layer()
             self.setValueFromRect(QgsReferencedRectangle(layer.extent(), layer.crs()))
 

--- a/kart/gui/featurehistorydialog.py
+++ b/kart/gui/featurehistorydialog.py
@@ -42,10 +42,10 @@ class FeatureHistoryDialog(BASE, WIDGET):
         self.workingCopyLayerIdField = None
         self.workingCopyLayerCrs = None
         self.setupUi(self)
-        self.setWindowFlags(Qt.Window)
+        self.setWindowFlags(Qt.WindowType.Window)
 
         self.bar = QgsMessageBar()
-        self.bar.setSizePolicy(QSizePolicy.Minimum, QSizePolicy.Fixed)
+        self.bar.setSizePolicy(QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Fixed)
         self.layout().insertWidget(0, self.bar)
 
         self.listCommits.currentRowChanged.connect(self.currentCommitChanged)
@@ -55,7 +55,7 @@ class FeatureHistoryDialog(BASE, WIDGET):
         horizontalLayout.setSpacing(0)
         horizontalLayout.setMargin(0)
         self.canvas = QgsMapCanvas()
-        self.canvas.setCanvasColor(Qt.white)
+        self.canvas.setCanvasColor(Qt.GlobalColor.white)
         horizontalLayout.addWidget(self.canvas)
         self.canvasWidget.setLayout(horizontalLayout)
         self.panTool = QgsMapToolPan(self.canvas)
@@ -125,7 +125,7 @@ class FeatureHistoryDialog(BASE, WIDGET):
         self.layer.setExtent(self.layer.boundingBoxOfSelected())
         self.layer.invertSelection()
         symbol = QgsSymbol.defaultSymbol(self.layer.geometryType())
-        symbol.setColor(Qt.green)
+        symbol.setColor(Qt.GlobalColor.green)
         symbol.setOpacity(0.5)
         self.layer.setRenderer(QgsSingleSymbolRenderer(symbol))
         self.canvas.setRenderFlag(False)
@@ -154,7 +154,7 @@ class FeatureHistoryDialog(BASE, WIDGET):
         self.bar.pushMessage(
             "Feature history",
             "Working copy has been correctly modified",
-            Qgis.Success,
+            Qgis.MessageLevel.Success,
             5,
         )
 

--- a/kart/gui/historyviewer.py
+++ b/kart/gui/historyviewer.py
@@ -49,15 +49,15 @@ PEN_WIDTH = 2
 MARGIN = 50
 
 COLORS = [
-    QColor(Qt.red),
-    QColor(Qt.green),
-    QColor(Qt.blue),
-    QColor(Qt.black),
+    QColor(Qt.GlobalColor.red),
+    QColor(Qt.GlobalColor.green),
+    QColor(Qt.GlobalColor.blue),
+    QColor(Qt.GlobalColor.black),
     QColor(255, 166, 0),
-    QColor(Qt.darkGreen),
-    QColor(Qt.darkBlue),
-    QColor(Qt.cyan),
-    QColor(Qt.magenta),
+    QColor(Qt.GlobalColor.darkGreen),
+    QColor(Qt.GlobalColor.darkBlue),
+    QColor(Qt.GlobalColor.cyan),
+    QColor(Qt.GlobalColor.magenta),
 ]
 
 
@@ -73,13 +73,13 @@ class HistoryTree(QTreeWidget):
         self.initGui()
 
     def initGui(self):
-        self.setContextMenuPolicy(Qt.CustomContextMenu)
+        self.setContextMenuPolicy(Qt.ContextMenuPolicy.CustomContextMenu)
         # self.header().setStretchLastSection(True)
         self.setHeaderLabels(
             ["Graph", "Refs", "Description", "Author", "Date", "CommitID"]
         )
         self.customContextMenuRequested.connect(self._showPopupMenu)
-        self.setSelectionMode(QAbstractItemView.ExtendedSelection)
+        self.setSelectionMode(QAbstractItemView.SelectionMode.ExtendedSelection)
         self.populate()
 
     def _showPopupMenu(self, point):
@@ -199,25 +199,25 @@ class HistoryTree(QTreeWidget):
         )
         if ok and name:
             self.repo.createTag(name, item.commit["commit"])
-            self.message("Tag correctly created", Qgis.Info)
+            self.message("Tag correctly created", Qgis.MessageLevel.Info)
             self.populate()
 
     @executeskart
     def deleteTag(self, tag):
         self.repo.deleteTag(tag)
-        self.message(f"Correctly deleted tag '{tag}'", Qgis.Info)
+        self.message(f"Correctly deleted tag '{tag}'", Qgis.MessageLevel.Info)
         self.populate()
 
     @executeskart
     def switchBranch(self, branch):
         self.repo.checkoutBranch(branch)
-        self.message(f"Correctly switched to branch '{branch}'", Qgis.Info)
+        self.message(f"Correctly switched to branch '{branch}'", Qgis.MessageLevel.Info)
         self.populate()
 
     @executeskart
     def deleteBranch(self, branch):
         self.repo.deleteBranch(branch)
-        self.message(f"Correctly deleted branch '{branch}'", Qgis.Info)
+        self.message(f"Correctly deleted branch '{branch}'", Qgis.MessageLevel.Info)
         self.populate()
 
     @executeskart
@@ -227,7 +227,7 @@ class HistoryTree(QTreeWidget):
         )
         if ok and name:
             self.repo.createBranch(name, item.commit["commit"])
-            self.message("Branch correctly created", Qgis.Info)
+            self.message("Branch correctly created", Qgis.MessageLevel.Info)
             self.populate()
 
     @executeskart
@@ -237,7 +237,7 @@ class HistoryTree(QTreeWidget):
         if hasSchemaChanges:
             self.message(
                 "There are schema changes in the selected commit and changes cannot be shown",
-                Qgis.Warning,
+                Qgis.MessageLevel.Warning,
             )
             return
         diff = self.repo.diff(refa, parent)
@@ -251,7 +251,7 @@ class HistoryTree(QTreeWidget):
             self.message(
                 "There are schema changes between the selected commits "
                 "and changes cannot be shown",
-                Qgis.Warning,
+                Qgis.MessageLevel.Warning,
             )
             return
         diff = self.repo.diff(refa, refb)
@@ -275,7 +275,7 @@ class HistoryTree(QTreeWidget):
             self.message(
                 "There are schema changes between the selected commits "
                 "and changes cannot be saved as a layer",
-                Qgis.Warning,
+                Qgis.MessageLevel.Warning,
             )
             return
         diff = self.repo.diff(refb, refa)
@@ -299,7 +299,9 @@ class HistoryTree(QTreeWidget):
     @executeskart
     def resetBranch(self, item):
         self.repo.reset(item.commit["commit"])
-        self.message("Branch correctly reset to selected commit", Qgis.Info)
+        self.message(
+            "Branch correctly reset to selected commit", Qgis.MessageLevel.Info
+        )
         self.populate()
 
     @executeskart
@@ -321,7 +323,8 @@ class HistoryTree(QTreeWidget):
                 dataset = None
             self.repo.restore(item.commit["commit"], dataset)
             self.message(
-                "Selected dataset(s) correctly restored in working copy", Qgis.Info
+                "Selected dataset(s) correctly restored in working copy",
+                Qgis.MessageLevel.Info,
             )
 
     def message(self, text, level):
@@ -361,8 +364,8 @@ class HistoryTree(QTreeWidget):
         for i in range(1, 6):
             self.resizeColumnToContents(i)
         self.setColumnWidth(0, width + MARGIN)
-        self.header().setSectionResizeMode(0, QHeaderView.Fixed)
-        self.header().setSectionResizeMode(1, QHeaderView.Fixed)
+        self.header().setSectionResizeMode(0, QHeaderView.ResizeMode.Fixed)
+        self.header().setSectionResizeMode(1, QHeaderView.ResizeMode.Fixed)
         self.filterCommits()
 
     def graphImage(self, commit, width):
@@ -370,7 +373,8 @@ class HistoryTree(QTreeWidget):
         qp = QPainter(image)
         palette = QWidget().palette()
         qp.fillRect(
-            QRectF(0, 0, width, COMMIT_GRAPH_HEIGHT), palette.color(QPalette.Base)
+            QRectF(0, 0, width, COMMIT_GRAPH_HEIGHT),
+            palette.color(QPalette.ColorRole.Base),
         )
 
         path = QPainterPath()
@@ -404,7 +408,7 @@ class HistoryTree(QTreeWidget):
             path.lineTo(x2, COMMIT_GRAPH_HEIGHT)
         pen = QPen()
         pen.setWidth(PEN_WIDTH)
-        pen.setBrush(palette.color(QPalette.WindowText))
+        pen.setBrush(palette.color(QPalette.ColorRole.WindowText))
         qp.setPen(pen)
         qp.drawPath(path)
 
@@ -437,7 +441,7 @@ class HistoryTree(QTreeWidget):
                     self.filterText in t.lower() for t in values
                 )
                 date = QDateTime.fromString(
-                    item.commit["authorTime"], Qt.ISODate
+                    item.commit["authorTime"], Qt.DateFormat.ISODate
                 ).date()
                 withinDates = date >= self.startDate and date <= self.endDate
                 hide = hide or not withinDates
@@ -516,7 +520,7 @@ class HistoryDialog(WIDGET, BASE):
     def __init__(self, repo, dataset=None):
         super(HistoryDialog, self).__init__(iface.mainWindow())
         self.setupUi(self)
-        self.setWindowFlags(Qt.Window)
+        self.setWindowFlags(Qt.WindowType.Window)
 
         self.dateEditStart.setDateTime(QDateTime.fromSecsSinceEpoch(0))
         self.dateEditEnd.setDateTime(QDateTime.currentDateTime())
@@ -524,7 +528,7 @@ class HistoryDialog(WIDGET, BASE):
         layout = QVBoxLayout()
         layout.setMargin(0)
         self.bar = QgsMessageBar()
-        self.bar.setSizePolicy(QSizePolicy.Minimum, QSizePolicy.Fixed)
+        self.bar.setSizePolicy(QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Fixed)
         layout.addWidget(self.bar)
         self.history = HistoryTree(repo, dataset, self)
         layout.addWidget(self.history)

--- a/kart/gui/initdialog.py
+++ b/kart/gui/initdialog.py
@@ -21,7 +21,7 @@ class InitDialog(BASE, WIDGET):
         self.setupUi(self)
 
         self.bar = QgsMessageBar()
-        self.bar.setSizePolicy(QSizePolicy.Minimum, QSizePolicy.Fixed)
+        self.bar.setSizePolicy(QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Fixed)
         self.layout().addWidget(self.bar)
 
         self.btnBrowse.clicked.connect(self.browse)
@@ -44,7 +44,7 @@ class InitDialog(BASE, WIDGET):
             self.location = self.locationPanel.location()
         except InvalidLocationException:
             self.bar.pushMessage(
-                "Invalid location definition", Qgis.Warning, duration=5
+                "Invalid location definition", Qgis.MessageLevel.Warning, duration=5
             )
             return
         self.folder = self.txtFolder.text()
@@ -52,5 +52,5 @@ class InitDialog(BASE, WIDGET):
             self.accept()
         else:
             self.bar.pushMessage(
-                "Text fields must not be empty", Qgis.Warning, duration=5
+                "Text fields must not be empty", Qgis.MessageLevel.Warning, duration=5
             )

--- a/kart/gui/installationwarningdialog.py
+++ b/kart/gui/installationwarningdialog.py
@@ -130,9 +130,9 @@ class InstallationWarningDialog(BASE, WIDGET):
         loop = QEventLoop()
         t.downloadProgressChanged.connect(self.progressBar.setValue)
         t.downloadFinished.connect(self.hide)
-        t.finished.connect(loop.exit, Qt.QueuedConnection)
+        t.finished.connect(loop.exit, Qt.ConnectionType.QueuedConnection)
         t.start()
-        loop.exec_(flags=QEventLoop.ExcludeUserInputEvents)
+        loop.exec(flags=QEventLoop.ProcessEventsFlag.ExcludeUserInputEvents)
         self.accept()
 
     def openSettings(self):

--- a/kart/gui/mapswipetool.py
+++ b/kart/gui/mapswipetool.py
@@ -17,8 +17,8 @@ class MapSwipeTool(QgsMapTool):
         self.layer = layer
         self.checkDirection = self.hasSwipe = self.disabledSwipe = None
         self.firstPoint = QPoint()
-        self.cursorV = QCursor(Qt.SplitVCursor)
-        self.cursorH = QCursor(Qt.SplitHCursor)
+        self.cursorV = QCursor(Qt.CursorShape.SplitVCursor)
+        self.cursorH = QCursor(Qt.CursorShape.SplitHCursor)
 
     def _connect(self, isConnect=True):
         if isConnect:
@@ -28,7 +28,7 @@ class MapSwipeTool(QgsMapTool):
 
     def activate(self):
         super().activate()
-        self.canvas().setCursor(QCursor(Qt.PointingHandCursor))
+        self.canvas().setCursor(QCursor(Qt.CursorShape.PointingHandCursor))
         self._connect()
         self.hasSwipe = False
         self.disabledSwipe = False
@@ -53,7 +53,7 @@ class MapSwipeTool(QgsMapTool):
 
     def canvasReleaseEvent(self, e):
         self.hasSwipe = False
-        self.canvas().setCursor(QCursor(Qt.PointingHandCursor))
+        self.canvas().setCursor(QCursor(Qt.CursorShape.PointingHandCursor))
 
     def canvasMoveEvent(self, e):
         THRESHOLD = 10
@@ -78,7 +78,7 @@ class MapSwipeTool(QgsMapTool):
                     self.cursorH if self.swipe.isVertical else self.cursorV
                 )
             else:
-                self.canvas().setCursor(QCursor(Qt.PointingHandCursor))
+                self.canvas().setCursor(QCursor(Qt.CursorShape.PointingHandCursor))
 
     def setLayersSwipe(self):
         if self.disabledSwipe:

--- a/kart/gui/pulldialog.py
+++ b/kart/gui/pulldialog.py
@@ -22,7 +22,7 @@ class PullDialog(BASE, WIDGET):
         self.setupUi(self)
 
         self.bar = QgsMessageBar()
-        self.bar.setSizePolicy(QSizePolicy.Minimum, QSizePolicy.Fixed)
+        self.bar.setSizePolicy(QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Fixed)
         self.layout().addWidget(self.bar)
 
         self.btnManageRemotes.clicked.connect(self.manageRemotes)
@@ -51,7 +51,10 @@ class PullDialog(BASE, WIDGET):
         self.remote = self.comboRemote.currentText()
         if not self.remote:
             self.bar.pushMessage(
-                "", "Branch and remote must not be empty", Qgis.Warning, duration=5
+                "",
+                "Branch and remote must not be empty",
+                Qgis.MessageLevel.Warning,
+                duration=5,
             )
         else:
             self.accept()

--- a/kart/gui/pushdialog.py
+++ b/kart/gui/pushdialog.py
@@ -22,7 +22,7 @@ class PushDialog(BASE, WIDGET):
         self.setupUi(self)
 
         self.bar = QgsMessageBar()
-        self.bar.setSizePolicy(QSizePolicy.Minimum, QSizePolicy.Fixed)
+        self.bar.setSizePolicy(QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Fixed)
         self.layout().addWidget(self.bar)
 
         self.chkPushAll.stateChanged.connect(self.checkPushAllStateChanged)
@@ -56,7 +56,10 @@ class PushDialog(BASE, WIDGET):
         self.remote = self.comboRemote.currentText()
         if not self.remote:
             self.bar.pushMessage(
-                "", "Branch and remote must not be empty", Qgis.Warning, duration=5
+                "",
+                "Branch and remote must not be empty",
+                Qgis.MessageLevel.Warning,
+                duration=5,
             )
         else:
             self.accept()

--- a/kart/gui/remotesdialog.py
+++ b/kart/gui/remotesdialog.py
@@ -23,7 +23,7 @@ class RemotesDialog(BASE, WIDGET):
         self.setupUi(self)
 
         self.bar = QgsMessageBar()
-        self.bar.setSizePolicy(QSizePolicy.Minimum, QSizePolicy.Fixed)
+        self.bar.setSizePolicy(QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Fixed)
         self.layout().addWidget(self.bar)
 
         self.listWidget.itemClicked.connect(self.itemClicked)
@@ -50,7 +50,7 @@ class RemotesDialog(BASE, WIDGET):
             self.bar.pushMessage(
                 "",
                 "Values for both remote name and url must be provided",
-                Qgis.Warning,
+                Qgis.MessageLevel.Warning,
                 duration=5,
             )
         else:
@@ -71,7 +71,10 @@ class RemotesDialog(BASE, WIDGET):
         item = self.itemFromName(name)
         if item is None:
             self.bar.pushMessage(
-                "", "A remote with that name does not exist", Qgis.Warning, duration=5
+                "",
+                "A remote with that name does not exist",
+                Qgis.MessageLevel.Warning,
+                duration=5,
             )
         else:
             self._removeRemote(name)

--- a/kart/gui/repopropertiesdialog.py
+++ b/kart/gui/repopropertiesdialog.py
@@ -25,7 +25,7 @@ class RepoPropertiesDialog(BASE, WIDGET):
         self.repo = repo
 
         self.bar = QgsMessageBar()
-        self.bar.setSizePolicy(QSizePolicy.Minimum, QSizePolicy.Fixed)
+        self.bar.setSizePolicy(QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Fixed)
         self.layout().addWidget(self.bar)
 
         self.buttonBox.accepted.connect(self.okClicked)
@@ -61,7 +61,9 @@ class RepoPropertiesDialog(BASE, WIDGET):
         if self.grpFilter.isChecked():
             extent = self.extentPanel.getExtent()
             if extent is None:
-                self.bar.pushMessage("Invalid extent value", Qgis.Warning, duration=5)
+                self.bar.pushMessage(
+                    "Invalid extent value", Qgis.MessageLevel.Warning, duration=5
+                )
                 return
         else:
             extent = None

--- a/kart/gui/settingsdialog.py
+++ b/kart/gui/settingsdialog.py
@@ -21,7 +21,7 @@ class SettingsDialog(BASE, WIDGET):
         self.setupUi(self)
 
         self.bar = QgsMessageBar()
-        self.bar.setSizePolicy(QSizePolicy.Minimum, QSizePolicy.Fixed)
+        self.bar.setSizePolicy(QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Fixed)
         self.layout().addWidget(self.bar)
 
         self.btnBrowsePath.clicked.connect(lambda: self.browse(self.txtKartPath))

--- a/kart/gui/swipemap.py
+++ b/kart/gui/swipemap.py
@@ -60,19 +60,19 @@ class SwipeMap(QgsMapCanvasItem):
         self.setRect(self.canvas.extent())
         self.image = QImage(
             QSize(self.canvas.size().width() - 2, self.canvas.size().height() - 2),
-            QImage.Format_ARGB32_Premultiplied,
+            QImage.Format.Format_ARGB32_Premultiplied,
         )
-        self.image.fill(QColor(Qt.transparent))
+        self.image.fill(QColor(Qt.GlobalColor.transparent))
 
         settings = QgsMapSettings(self.canvas.mapSettings())
         settings.setLayers(self.layers)
-        settings.setBackgroundColor(QColor(Qt.transparent))
+        settings.setBackgroundColor(QColor(Qt.GlobalColor.transparent))
         settings.setExtent(self.canvas.extent())
         settings.setOutputSize(self.image.size())
 
         p = QPainter()
         p.begin(self.image)
-        p.setRenderHint(QPainter.Antialiasing)
+        p.setRenderHint(QPainter.RenderHint.Antialiasing)
         job = QgsMapRendererCustomPainterJob(settings, p)
         job.start()
         job.waitForFinished()

--- a/kart/gui/userconfigdialog.py
+++ b/kart/gui/userconfigdialog.py
@@ -21,7 +21,7 @@ class UserConfigDialog(BASE, WIDGET):
         self.setupUi(self)
 
         self.bar = QgsMessageBar()
-        self.bar.setSizePolicy(QSizePolicy.Minimum, QSizePolicy.Fixed)
+        self.bar.setSizePolicy(QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Fixed)
         self.layout().addWidget(self.bar)
 
         self.buttonBox.accepted.connect(self.okClicked)
@@ -36,5 +36,8 @@ class UserConfigDialog(BASE, WIDGET):
             self.accept()
         else:
             self.bar.pushMessage(
-                "", "Username and email must not be empty", Qgis.Warning, duration=5
+                "",
+                "Username and email must not be empty",
+                Qgis.MessageLevel.Warning,
+                duration=5,
             )

--- a/kart/kartapi.py
+++ b/kart/kartapi.py
@@ -15,6 +15,7 @@ from qgis.PyQt.QtCore import Qt
 from qgis.PyQt.QtGui import QColor
 from qgis.PyQt.QtWidgets import (
     QApplication,
+    QDialog,
 )
 
 from qgis.core import (
@@ -218,7 +219,7 @@ def executeKart(commands, path=None, jsonoutput=False, feedback=None):
     executeKart.env["KART_RASTER_VRTS"] = "1"
 
     try:
-        encoding = locale.getdefaultlocale()[1] or "utf-8"
+        encoding = locale.getpreferredencoding(False)
         QApplication.setOverrideCursor(Qt.CursorShape.WaitCursor)
         logging.debug(f"Command: {' '.join(commands)}")
         # TODO - all of this should be replaced by useage of QgsTask which
@@ -417,7 +418,7 @@ class Repository:
         if all(configDict.get(configKey) for configKey in ("user.name", "user.email")):
             return True
         dlg = UserConfigDialog(configDict)
-        if dlg.exec() == dlg.Accepted:
+        if dlg.exec() == QDialog.DialogCode.Accepted:
             self.configureUser(dlg.username, dlg.email)
             return True
         else:

--- a/kart/kartapi.py
+++ b/kart/kartapi.py
@@ -38,7 +38,7 @@ from kart import logging
 
 
 MINIMUM_SUPPORTED_VERSION = "0.14.0"
-CURRENT_VERSION = "0.15.3"
+CURRENT_VERSION = "0.17.0"
 
 
 class KartException(Exception):

--- a/kart/kartapi.py
+++ b/kart/kartapi.py
@@ -77,7 +77,7 @@ def executeskart(f):
                     <p><b>Kart failed with the following message:</b></p>
                     <p style="color:red">{errors}</p>
                     """
-            dlg.setMessage(msg, QgsMessageOutput.MessageHtml)
+            dlg.setMessage(msg, QgsMessageOutput.MessageType.MessageHtml)
             dlg.showMessage()
 
     return inner
@@ -137,14 +137,14 @@ def checkKartInstalled(showMessage=True, useCache=True):
                 iface.messageBar().pushMessage(
                     "Install",
                     "Kart has been correctly installed",
-                    level=Qgis.Success,
+                    level=Qgis.MessageLevel.Success,
                 )
                 return True
             else:
                 iface.messageBar().pushMessage(
                     "Install",
                     "Kart was not installed. Please install it manually.",
-                    level=Qgis.Warning,
+                    level=Qgis.MessageLevel.Warning,
                 )
         return False
     else:
@@ -219,7 +219,7 @@ def executeKart(commands, path=None, jsonoutput=False, feedback=None):
 
     try:
         encoding = locale.getdefaultlocale()[1] or "utf-8"
-        QApplication.setOverrideCursor(Qt.WaitCursor)
+        QApplication.setOverrideCursor(Qt.CursorShape.WaitCursor)
         logging.debug(f"Command: {' '.join(commands)}")
         # TODO - all of this should be replaced by useage of QgsTask which
         #  will execute on a background thread. There are a number of

--- a/kart/layers.py
+++ b/kart/layers.py
@@ -65,7 +65,7 @@ class LayerTracker:
         self.showLogAction = QAction(icons.logIcon, "Show Log...", iface)
         self.showLogAction.triggered.connect(_f(self.showLog))
         iface.addCustomActionForLayerType(
-            self.showLogAction, "Kart", QgsMapLayer.VectorLayer, False
+            self.showLogAction, "Kart", QgsMapLayer.LayerType.VectorLayer, False
         )
 
         self.showWorkingTreeChangesAction = QAction(
@@ -75,7 +75,10 @@ class LayerTracker:
             _f(self.showWorkingTreeChanges)
         )
         iface.addCustomActionForLayerType(
-            self.showWorkingTreeChangesAction, "Kart", QgsMapLayer.VectorLayer, False
+            self.showWorkingTreeChangesAction,
+            "Kart",
+            QgsMapLayer.LayerType.VectorLayer,
+            False,
         )
 
         self.discardWorkingTreeChangesAction = QAction(
@@ -85,7 +88,10 @@ class LayerTracker:
             _f(self.discardWorkingTreeChanges)
         )
         iface.addCustomActionForLayerType(
-            self.discardWorkingTreeChangesAction, "Kart", QgsMapLayer.VectorLayer, False
+            self.discardWorkingTreeChangesAction,
+            "Kart",
+            QgsMapLayer.LayerType.VectorLayer,
+            False,
         )
 
         self.commitWorkingTreeChangesAction = QAction(
@@ -95,7 +101,10 @@ class LayerTracker:
             _f(self.commitWorkingTreeChanges)
         )
         iface.addCustomActionForLayerType(
-            self.commitWorkingTreeChangesAction, "Kart", QgsMapLayer.VectorLayer, False
+            self.commitWorkingTreeChangesAction,
+            "Kart",
+            QgsMapLayer.LayerType.VectorLayer,
+            False,
         )
 
         self.setMapToolAction = QAction(
@@ -103,7 +112,7 @@ class LayerTracker:
         )
         self.setMapToolAction.triggered.connect(_f(self.setMapTool))
         iface.addCustomActionForLayerType(
-            self.setMapToolAction, "Kart", QgsMapLayer.VectorLayer, False
+            self.setMapToolAction, "Kart", QgsMapLayer.LayerType.VectorLayer, False
         )
 
     @executeskart
@@ -117,7 +126,7 @@ class LayerTracker:
             iface.pushMessage(
                 "Kart",
                 "There are more than one Kart layers selected",
-                level=Qgis.Warning,
+                level=Qgis.MessageLevel.Warning,
             )
             return None, None
         else:
@@ -138,7 +147,7 @@ class LayerTracker:
                 iface.addCustomActionForLayer(
                     self.discardWorkingTreeChangesAction, layer
                 )
-                if layer.wkbType() != QgsWkbTypes.NoGeometry:
+                if layer.wkbType() != QgsWkbTypes.Type.NoGeometry:
                     iface.addCustomActionForLayer(self.setMapToolAction, layer)
 
                 self.updateRubberBands()
@@ -186,11 +195,11 @@ class LayerTracker:
                 rect = repo.spatialFilter()
                 if rect is not None and repo.showBoundingBox:
                     rubberBand = QgsRubberBand(
-                        iface.mapCanvas(), QgsWkbTypes.PolygonGeometry
+                        iface.mapCanvas(), QgsWkbTypes.GeometryType.PolygonGeometry
                     )
                     rubberBand.setFillColor(QColor(0, 0, 0, 0))
                     rubberBand.setWidth(1)
-                    rubberBand.setLineStyle(Qt.DotLine)
+                    rubberBand.setLineStyle(Qt.PenStyle.DotLine)
                     if repo.showBoundingBox:
                         rubberBand.setStrokeColor(repo.boundingBoxColor)
                     else:
@@ -237,7 +246,7 @@ class LayerTracker:
         feats = self.mapToolLayer.getFeatures(
             QgsFeatureRequest()
             .setFilterRect(r)
-            .setFlags(QgsFeatureRequest.ExactIntersect)
+            .setFlags(QgsFeatureRequest.Flag.ExactIntersect)
         )
         dataset = self.mapToolRepo.datasetNameFromLayer(self.mapToolLayer)
         idField = self.mapToolRepo.workingCopyLayerIdField(dataset)
@@ -253,7 +262,7 @@ class LayerTracker:
             iface.messageBar().pushMessage(
                 "Kart",
                 "No feature was found at the selected point.",
-                level=Qgis.Warning,
+                level=Qgis.MessageLevel.Warning,
             )
 
     @executeskart
@@ -274,7 +283,7 @@ class LayerTracker:
                 iface.messageBar().pushMessage(
                     "Changes",
                     "There are schema changes in the working tree and changes cannot be shown",
-                    level=Qgis.Warning,
+                    level=Qgis.MessageLevel.Warning,
                 )
                 return
             diff = repo.diff(dataset=dataset)
@@ -287,7 +296,7 @@ class LayerTracker:
                 iface.messageBar().pushMessage(
                     "Changes",
                     "There are no changes in the working copy",
-                    level=Qgis.Warning,
+                    level=Qgis.MessageLevel.Warning,
                 )
 
     @executeskart
@@ -299,7 +308,7 @@ class LayerTracker:
             iface.messageBar().pushMessage(
                 "Discard changes",
                 f"Working copy changes for layer '{layer.name()}' have been discarded",
-                level=Qgis.Info,
+                level=Qgis.MessageLevel.Info,
             )
 
     @executeskart
@@ -315,17 +324,19 @@ class LayerTracker:
                 if ok and msg:
                     if repo.commit(msg, dataset=dataset):
                         iface.messageBar().pushMessage(
-                            "Commit", "Changes correctly committed", level=Qgis.Info
+                            "Commit",
+                            "Changes correctly committed",
+                            level=Qgis.MessageLevel.Info,
                         )
                     else:
                         iface.messageBar().pushMessage(
                             "Commit",
                             "Changes could not be commited",
-                            level=Qgis.Warning,
+                            level=Qgis.MessageLevel.Warning,
                         )
             else:
                 iface.messageBar().pushMessage(
-                    "Commit", "Nothing to commit", level=Qgis.Warning
+                    "Commit", "Nothing to commit", level=Qgis.MessageLevel.Warning
                 )
 
     def layerRemoved(self, layerid):
@@ -340,7 +351,9 @@ class LayerTracker:
                 dataset = repo.datasetNameFromLayer(layer)
                 repo.commit(f"Changed dataset '{dataset}'", dataset=dataset)
                 iface.messageBar().pushMessage(
-                    "Commit", "Changes correctly committed", level=Qgis.Info
+                    "Commit",
+                    "Changes correctly committed",
+                    level=Qgis.MessageLevel.Info,
                 )
 
     def disconnectLayers(self):

--- a/kart/logging.py
+++ b/kart/logging.py
@@ -4,7 +4,7 @@ DEBUG = True
 MAX_LINES = 20
 
 
-def _log(msg, level=Qgis.Info):
+def _log(msg, level=Qgis.MessageLevel.Info):
     lines = msg.splitlines()
     if len(lines) > 20:
         msg = "\n".join(lines[:20]) + f"\n[Showing only the first {MAX_LINES} lines]"
@@ -12,11 +12,11 @@ def _log(msg, level=Qgis.Info):
 
 
 def info(msg):
-    _log(msg, Qgis.Info)
+    _log(msg, Qgis.MessageLevel.Info)
 
 
 def error(msg):
-    _log(msg, Qgis.Critical)
+    _log(msg, Qgis.MessageLevel.Critical)
 
 
 def debug(msg):

--- a/kart/metadata.txt
+++ b/kart/metadata.txt
@@ -24,3 +24,4 @@ tracker=https://github.com/koordinates/kart-qgis-plugin/issues
 icon=img/kart.png
 category=Plugins
 hasProcessingProvider=yes
+supportsQt6=True

--- a/kart/plugin.py
+++ b/kart/plugin.py
@@ -29,7 +29,7 @@ class KartPlugin(object):
     def initGui(self):
 
         self.dock = KartDockWidget()
-        self.iface.addDockWidget(Qt.RightDockWidgetArea, self.dock)
+        self.iface.addDockWidget(Qt.DockWidgetArea.RightDockWidgetArea, self.dock)
 
         self.explorerAction = QAction("Repositories...", self.iface.mainWindow())
         self.iface.addPluginToMenu("Kart", self.explorerAction)
@@ -83,7 +83,7 @@ class KartPlugin(object):
         )
         dlg = QgsMessageOutput.createMessageOutput()
         dlg.setTitle("About Kart")
-        dlg.setMessage(html, QgsMessageOutput.MessageHtml)
+        dlg.setMessage(html, QgsMessageOutput.MessageType.MessageHtml)
         dlg.showMessage()
 
     def unload(self):

--- a/kart/processing/branches.py
+++ b/kart/processing/branches.py
@@ -23,7 +23,7 @@ class RepoCreateBranch(KartAlgorithm):
             QgsProcessingParameterFile(
                 self.REPO_PATH,
                 self.tr("Repo Path"),
-                behavior=QgsProcessingParameterFile.Folder,
+                behavior=QgsProcessingParameterFile.Behavior.Folder,
             )
         )
 
@@ -67,7 +67,7 @@ class RepoSwitchBranch(KartAlgorithm):
             QgsProcessingParameterFile(
                 self.REPO_PATH,
                 self.tr("Repo Path"),
-                behavior=QgsProcessingParameterFile.Folder,
+                behavior=QgsProcessingParameterFile.Behavior.Folder,
             )
         )
 
@@ -111,7 +111,7 @@ class RepoDeleteBranch(KartAlgorithm):
             QgsProcessingParameterFile(
                 self.REPO_PATH,
                 self.tr("Repo Path"),
-                behavior=QgsProcessingParameterFile.Folder,
+                behavior=QgsProcessingParameterFile.Behavior.Folder,
             )
         )
 

--- a/kart/processing/data.py
+++ b/kart/processing/data.py
@@ -28,7 +28,7 @@ class RepoImportData(KartAlgorithm):
             QgsProcessingParameterFile(
                 self.REPO_PATH,
                 self.tr("Repo Path"),
-                behavior=QgsProcessingParameterFile.Folder,
+                behavior=QgsProcessingParameterFile.Behavior.Folder,
             )
         )
 
@@ -36,7 +36,7 @@ class RepoImportData(KartAlgorithm):
             QgsProcessingParameterFile(
                 self.REPO_DATA_PATH,
                 self.tr("Data Path"),
-                behavior=QgsProcessingParameterFile.File,
+                behavior=QgsProcessingParameterFile.Behavior.File,
             )
         )
 

--- a/kart/processing/remotes.py
+++ b/kart/processing/remotes.py
@@ -24,7 +24,7 @@ class RepoPushToRemote(KartAlgorithm):
             QgsProcessingParameterFile(
                 self.REPO_PATH,
                 self.tr("Repo Path"),
-                behavior=QgsProcessingParameterFile.Folder,
+                behavior=QgsProcessingParameterFile.Behavior.Folder,
             )
         )
 
@@ -78,7 +78,7 @@ class RepoPullFromRemote(KartAlgorithm):
             QgsProcessingParameterFile(
                 self.REPO_PATH,
                 self.tr("Repo Path"),
-                behavior=QgsProcessingParameterFile.Folder,
+                behavior=QgsProcessingParameterFile.Behavior.Folder,
             )
         )
 

--- a/kart/processing/repos.py
+++ b/kart/processing/repos.py
@@ -32,7 +32,7 @@ class RepoInit(KartAlgorithm):
             QgsProcessingParameterFile(
                 self.REPO_PATH,
                 self.tr("Repo Path"),
-                behavior=QgsProcessingParameterFile.Folder,
+                behavior=QgsProcessingParameterFile.Behavior.Folder,
             )
         )
 
@@ -94,7 +94,7 @@ class RepoClone(KartAlgorithm):
             QgsProcessingParameterNumber(
                 self.REPO_CLONE_DEPTH,
                 self.tr("Depth"),
-                type=QgsProcessingParameterNumber.Integer,
+                type=QgsProcessingParameterNumber.Type.Integer,
                 optional=True,
                 minValue=1,
             )

--- a/kart/processing/tags.py
+++ b/kart/processing/tags.py
@@ -23,7 +23,7 @@ class RepoCreateTag(KartAlgorithm):
             QgsProcessingParameterFile(
                 self.REPO_PATH,
                 self.tr("Repo Path"),
-                behavior=QgsProcessingParameterFile.Folder,
+                behavior=QgsProcessingParameterFile.Behavior.Folder,
             )
         )
 

--- a/kart/utils.py
+++ b/kart/utils.py
@@ -24,9 +24,11 @@ class ProgressBar:
         self.progress = QProgressBar()
         self.progress.setRange(0, 100)
         self.progress.setValue(0)
-        self.progress.setAlignment(Qt.AlignLeft | Qt.AlignVCenter)
+        self.progress.setAlignment(
+            Qt.AlignmentFlag.AlignLeft | Qt.AlignmentFlag.AlignVCenter
+        )
         self.progressMessageBar.layout().addWidget(self.progress)
-        iface.messageBar().pushWidget(self.progressMessageBar, Qgis.Info)
+        iface.messageBar().pushWidget(self.progressMessageBar, Qgis.MessageLevel.Info)
         QCoreApplication.processEvents()
 
     def setValue(self, value):
@@ -54,7 +56,7 @@ def progressBar(title):
 def waitcursor(method):
     def func(*args, **kw):
         try:
-            QApplication.setOverrideCursor(Qt.WaitCursor)
+            QApplication.setOverrideCursor(Qt.CursorShape.WaitCursor)
             return method(*args, **kw)
         except Exception as ex:
             raise ex
@@ -66,9 +68,12 @@ def waitcursor(method):
 
 def confirm(msg):
     ret = QMessageBox.warning(
-        iface.mainWindow(), "Kart", msg, QMessageBox.Yes | QMessageBox.No
+        iface.mainWindow(),
+        "Kart",
+        msg,
+        QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
     )
-    return ret == QMessageBox.Yes
+    return ret == QMessageBox.StandardButton.Yes
 
 
 def layerFromSource(path):


### PR DESCRIPTION
per https://github.com/qgis/QGIS/wiki/Plugin-migration-to-be-compatible-with-Qt5-and-Qt6

* automatic changes produced by pyqt5_to_pyqt6, plus the necessary tweak to metadata.txt
* small tweaks to avoid a deprecation warning and a clone error

# todo
* [ ] check whether this works with QGIS 3.x still (if not, we need to bump `qgisMinimumVersion` in `metadata.txt`)
