### PR TITLE
Add double-click on dataset to add it to QGIS project

### DIFF
--- a/kart/gui/dockwidget.py
+++ b/kart/gui/dockwidget.py
@@ -79,6 +79,12 @@ class KartDockWidget(BASE, WIDGET):
 
         self.tree.itemExpanded.connect(onItemExpanded)
 
+        def onItemDoubleClicked(item, column):
+            if isinstance(item, DatasetItem):
+                item.addToProject()
+
+        self.tree.itemDoubleClicked.connect(onItemDoubleClicked)
+
         def mimeTypes():
             return ["application/x-vnd.qgis.qgis.uri"]
 


### PR DESCRIPTION
**Description:**
This PR introduces the ability to load a dataset into QGIS by double-clicking it in the Kart panel.

**Why:**
To align with standard QGIS behavior (e.g., the Browser Panel).

**Changes:**

- Added a double-click event listener to the dataset list.
- Connected the double-click action to the existing "Add to Project" functionality.