### PR TITLE
Switch lint/format tooling to ruff

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,15 +11,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      # Pin to the same ruff version used by the pre-commit hook so CI and
-      # local developer runs can't disagree.
+      # NOTE: keep these versions in sync with .pre-commmit-config.yaml
       - name: ruff check
-        uses: astral-sh/ruff-action@v3
+        uses: astral-sh/ruff-action@v4.0.0
         with:
-          version: "0.12.7"
+          version: "0.15.11"
           args: "check"
       - name: ruff format
-        uses: astral-sh/ruff-action@v3
+        uses: astral-sh/ruff-action@v4.0.0
         with:
-          version: "0.12.7"
+          version: "0.15.11"
           args: "format --check"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,7 +3,7 @@ name: Linting
 on: [push, pull_request]
 
 jobs:
-  flake8-lint:
+  ruff-lint:
     name: Lint
     runs-on: ubuntu-latest
 
@@ -11,10 +11,15 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
+      # Pin to the same ruff version used by the pre-commit hook so CI and
+      # local developer runs can't disagree.
+      - name: ruff check
+        uses: astral-sh/ruff-action@v3
         with:
-          python-version: "3.11"
-
-      - name: flake8 Lint
-        uses: py-actions/flake8@v1
+          version: "0.12.7"
+          args: "check"
+      - name: ruff format
+        uses: astral-sh/ruff-action@v3
+        with:
+          version: "0.12.7"
+          args: "format --check"

--- a/.hooks/kx-ruff.py
+++ b/.hooks/kx-ruff.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python3
+import subprocess
+import sys
+
+filez = sys.argv[1:]
+
+print("Running ruff linter")
+subprocess.check_call(["ruff", "check", "--fix", "--force-exclude", *filez])
+
+print("Running ruff formatter")
+subprocess.check_call(["ruff", "format", "--force-exclude", *filez])
+
+# pre-commit doesn't add changed files to the index. Normally changed files fail the hook.
+# however, just calling git add sneakily works around that.
+subprocess.check_call(["git", "add"] + filez)

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@
 ---
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.5.0
+    rev: v6.0.0
     hooks:
       - id: trailing-whitespace
         # Qt translation files must preserve source strings byte-for-byte
@@ -12,10 +12,12 @@ repos:
         exclude: '^kart/i18n/.*\.ts$'
       - id: check-yaml
       - id: check-json
+
+  # NOTE: keep this version in sync with .github/workflows/lint.yml
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.12.7
+    rev: v0.15.11
     hooks:
-      - id: ruff
+      - id: ruff-check
         # Run both the linter (with --fix) and formatter via a custom script
         # so autofixes are committed automatically.
         entry: ".hooks/kx-ruff.py"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,9 +6,16 @@ repos:
     rev: v2.5.0
     hooks:
       - id: trailing-whitespace
+        # Qt translation files must preserve source strings byte-for-byte
+        # (they're keyed off the exact Python string, including trailing
+        # spaces before \n).
+        exclude: '^kart/i18n/.*\.ts$'
       - id: check-yaml
       - id: check-json
-  - repo: https://github.com/psf/black
-    rev: "22.6.0"
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.12.7
     hooks:
-      - id: black
+      - id: ruff
+        # Run both the linter (with --fix) and formatter via a custom script
+        # so autofixes are committed automatically.
+        entry: ".hooks/kx-ruff.py"

--- a/helper.py
+++ b/helper.py
@@ -6,12 +6,10 @@ import os
 import re
 import shutil
 import sys
-import urllib.parse
 import xmlrpc.client
 import zipfile
 import subprocess
 import glob
-import re
 from configparser import ConfigParser
 from io import StringIO
 
@@ -142,7 +140,7 @@ def publish(archive):
     with open(archive, "rb") as fd:
         blob = xmlrpc.client.Binary(fd.read())
     conn.plugin.upload(blob)
-    print(f"Upload complete")
+    print("Upload complete")
 
 
 def usage():

--- a/kart/core/repo_manager.py
+++ b/kart/core/repo_manager.py
@@ -1,21 +1,11 @@
-from typing import (
-    Optional,
-    List
-)
-
-from qgis.PyQt.QtCore import (
-    QObject,
-    pyqtSignal
-)
+from typing import List, Optional
 
 from qgis.core import QgsMapLayer
+from qgis.PyQt.QtCore import QObject, pyqtSignal
 
-from kart.utils import setting, setSetting
+from kart.utils import setSetting, setting
 
-from ..kartapi import (
-    Repository,
-    KartException
-)
+from ..kartapi import KartException, Repository
 
 
 class RepoManager(QObject):
@@ -23,13 +13,13 @@ class RepoManager(QObject):
     Manages the local repositories
     """
 
-    _instance: Optional['RepoManager'] = None
+    _instance: Optional["RepoManager"] = None
 
     repo_added = pyqtSignal(Repository)
     repo_removed = pyqtSignal(Repository)
 
     @classmethod
-    def instance(cls) -> 'RepoManager':
+    def instance(cls) -> "RepoManager":
         """
         Returns the repo manager instance
         """

--- a/kart/gui/clonedialog.py
+++ b/kart/gui/clonedialog.py
@@ -1,19 +1,17 @@
 import os
 
 from qgis.core import Qgis
-from qgis.utils import iface
 from qgis.gui import QgsMessageBar
-
 from qgis.PyQt import uic
-from qgis.PyQt.QtCore import Qt, QCoreApplication
-from qgis.PyQt.QtWidgets import QDialog, QSizePolicy, QFileDialog
+from qgis.PyQt.QtCore import Qt
+from qgis.PyQt.QtWidgets import QDialog, QFileDialog, QSizePolicy
+from qgis.utils import iface
 
 from kart.gui.extentselectionpanel import ExtentSelectionPanel
 from kart.gui.locationselectionpanel import (
-    LocationSelectionPanel,
     InvalidLocationException,
+    LocationSelectionPanel,
 )
-
 from kart.utils import tr
 
 WIDGET, BASE = uic.loadUiType(os.path.join(os.path.dirname(__file__), "clonedialog.ui"))
@@ -51,9 +49,7 @@ class CloneDialog(BASE, WIDGET):
         self.txtSrc.setText(src)
 
     def browse(self, textbox):
-        folder = QFileDialog.getExistingDirectory(
-            iface.mainWindow(), tr("Select Folder"), ""
-        )
+        folder = QFileDialog.getExistingDirectory(iface.mainWindow(), tr("Select Folder"), "")
         if folder:
             textbox.setText(folder)
 

--- a/kart/gui/conflictsdialog.py
+++ b/kart/gui/conflictsdialog.py
@@ -1,29 +1,25 @@
 import os
 
-from qgis.utils import iface
 from qgis.core import Qgis
 from qgis.gui import QgsMessageBar
-
 from qgis.PyQt import uic
-from qgis.PyQt.QtCore import QSize, Qt, QCoreApplication
+from qgis.PyQt.QtCore import QSize, Qt
 from qgis.PyQt.QtGui import QFont
 from qgis.PyQt.QtWidgets import (
     QDialog,
-    QTreeWidgetItem,
-    QMessageBox,
-    QTableWidgetItem,
     QHeaderView,
+    QMessageBox,
     QSizePolicy,
+    QTableWidgetItem,
+    QTreeWidgetItem,
     QTreeWidgetItemIterator,
 )
+from qgis.utils import iface
 
 from kart.gui import icons
 from kart.utils import tr
 
-
-WIDGET, BASE = uic.loadUiType(
-    os.path.join(os.path.dirname(__file__), "conflictsdialog.ui")
-)
+WIDGET, BASE = uic.loadUiType(os.path.join(os.path.dirname(__file__), "conflictsdialog.ui"))
 
 
 class ConflictsDialog(BASE, WIDGET):
@@ -122,9 +118,7 @@ class ConflictsDialog(BASE, WIDGET):
         ret = QMessageBox.warning(
             self,
             tr("Solve conflicts"),
-            tr(
-                "Are you sure you want to solve all conflicts using the 'ours' version?"
-            ),
+            tr("Are you sure you want to solve all conflicts using the 'ours' version?"),
             QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
             QMessageBox.StandardButton.Yes,
         )
@@ -135,9 +129,7 @@ class ConflictsDialog(BASE, WIDGET):
         ret = QMessageBox.warning(
             self,
             tr("Solve conflicts"),
-            tr(
-                "Are you sure you want to solve all conflicts using the 'theirs' version?"
-            ),
+            tr("Are you sure you want to solve all conflicts using the 'theirs' version?"),
             QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
             QMessageBox.StandardButton.Yes,
         )
@@ -175,9 +167,7 @@ class ConflictsDialog(BASE, WIDGET):
                     Qgis.MessageLevel.Warning,
                 )
                 return
-        feature[
-            "id"
-        ] = f"{self.lastSelectedItem.path}:feature:{self.lastSelectedItem.fid}"
+        feature["id"] = f"{self.lastSelectedItem.path}:feature:{self.lastSelectedItem.fid}"
         self.resolvedFeatures[feature["id"]] = feature
         self.updateAfterSolvingCurrentItem()
 
@@ -191,9 +181,7 @@ class ConflictsDialog(BASE, WIDGET):
                 QMessageBox.warning(
                     self,
                     tr("Solve conflicts"),
-                    tr(
-                        "All conflicts are solved. The merge operation will now be closed"
-                    ),
+                    tr("All conflicts are solved. The merge operation will now be closed"),
                     QMessageBox.StandardButton.Ok,
                     QMessageBox.StandardButton.Ok,
                 )
@@ -207,18 +195,14 @@ class ConflictsDialog(BASE, WIDGET):
     def solveOurs(self):
         conflict = self.lastSelectedItem.conflict
         feature = dict(conflict["ours"])
-        feature[
-            "id"
-        ] = f"{self.lastSelectedItem.path}:feature:{self.lastSelectedItem.fid}"
+        feature["id"] = f"{self.lastSelectedItem.path}:feature:{self.lastSelectedItem.fid}"
         self.resolvedFeatures[feature["id"]] = feature
         self.updateAfterSolvingCurrentItem()
 
     def solveTheirs(self):
         conflict = self.lastSelectedItem.conflict
         feature = dict(conflict["theirs"])
-        feature[
-            "id"
-        ] = f"{self.lastSelectedItem.path}:feature:{self.lastSelectedItem.fid}"
+        feature["id"] = f"{self.lastSelectedItem.path}:feature:{self.lastSelectedItem.fid}"
         self.resolvedFeatures[feature["id"]] = feature
         self.updateAfterSolvingCurrentItem()
 
@@ -231,18 +215,14 @@ class ConflictsDialog(BASE, WIDGET):
         conflict = self.lastSelectedItem.conflict
         feature = conflict["ours"] or conflict["theirs"]
         feature = dict(feature)
-        feature[
-            "id"
-        ] = f"{self.lastSelectedItem.path}:feature:{self.lastSelectedItem.fid}"
+        feature["id"] = f"{self.lastSelectedItem.path}:feature:{self.lastSelectedItem.fid}"
         self.resolvedFeatures[feature["id"]] = feature
         self.updateAfterSolvingCurrentItem()
 
     def solveWithAncestor(self):
         conflict = self.lastSelectedItem.conflict
         feature = dict(conflict["ancestor"])
-        feature[
-            "id"
-        ] = f"{self.lastSelectedItem.path}:feature:{self.lastSelectedItem.fid}"
+        feature["id"] = f"{self.lastSelectedItem.path}:feature:{self.lastSelectedItem.fid}"
         self.resolvedFeatures[feature["id"]] = feature
         self.updateAfterSolvingCurrentItem()
 
@@ -276,11 +256,7 @@ class ConflictsDialog(BASE, WIDGET):
                     value = feature["properties"][name]
                 values.append(value)
 
-            ok = (
-                values[0] == values[1]
-                or values[1] == values[2]
-                or values[0] == values[2]
-            )
+            ok = values[0] == values[1] or values[1] == values[2] or values[0] == values[2]
 
             for i, v in enumerate(values):
                 self.tableAttributes.setItem(idx, i, ValueItem(v, not ok))
@@ -324,17 +300,19 @@ class ConflictsDialog(BASE, WIDGET):
         self.label_2.setText(tr("Click on a value to use it in the merged feature"))
         self.btnSolveOurs.setText(tr("Use values from ours"))
         self.btnSolveTheirs.setText(tr("Use values from theirs"))
-        self.tableAttributes.setHorizontalHeaderLabels([
-            tr("Ancestor"), tr("Theirs"), tr("Ours"), tr("ATTRIBUTE"), tr("Merged")
-        ])
+        self.tableAttributes.setHorizontalHeaderLabels(
+            [tr("Ancestor"), tr("Theirs"), tr("Ours"), tr("ATTRIBUTE"), tr("Merged")]
+        )
         self.btnSolveFeature.setText(tr("Solve feature with table values above"))
         self.btnDeleteFeature.setText(tr("Delete feature"))
         self.btnUseAncestor.setText(tr("Use ancestor feature"))
         self.btnUseModified.setText(tr("Use modified feature"))
-        self.label_3.setText(tr(
-            "This feature has been modified in one of the branches.\n\n"
-            "Select how you want to solve this conflict:"
-        ))
+        self.label_3.setText(
+            tr(
+                "This feature has been modified in one of the branches.\n\n"
+                "Select how you want to solve this conflict:"
+            )
+        )
 
 
 class ValueItem(QTableWidgetItem):
@@ -386,4 +364,3 @@ class ConflictItem(QTreeWidgetItem):
         self.conflict = conflict
         self.fid = fid
         self.path = path
-

--- a/kart/gui/dbconnectiondialog.py
+++ b/kart/gui/dbconnectiondialog.py
@@ -1,24 +1,19 @@
 import os
 
-from qgis.utils import iface
-
-from qgis.PyQt import uic
-from qgis.PyQt.QtCore import QCoreApplication
-from qgis.PyQt.QtWidgets import QDialog, QSizePolicy
 from qgis.core import (
     Qgis,
     QgsApplication,
     QgsAuthMethodConfig,
 )
-
 from qgis.gui import QgsAuthSettingsWidget, QgsMessageBar
+from qgis.PyQt import uic
+from qgis.PyQt.QtWidgets import QDialog, QSizePolicy
+from qgis.utils import iface
 
 from kart.kartapi import Repository
-from kart.utils import waitcursor, tr
+from kart.utils import tr, waitcursor
 
-WIDGET, BASE = uic.loadUiType(
-    os.path.join(os.path.dirname(__file__), "dbconnectiondialog.ui")
-)
+WIDGET, BASE = uic.loadUiType(os.path.join(os.path.dirname(__file__), "dbconnectiondialog.ui"))
 
 
 class DbConnectionDialog(BASE, WIDGET):
@@ -103,9 +98,7 @@ class DbConnectionDialog(BASE, WIDGET):
             authid = self.authWidget.configId()
             if authid:
                 authConfig = QgsAuthMethodConfig()
-                QgsApplication.authManager().loadAuthenticationConfig(
-                    authid, authConfig, True
-                )
+                QgsApplication.authManager().loadAuthenticationConfig(authid, authConfig, True)
                 username = authConfig.config("username")
                 password = authConfig.config("password")
             else:

--- a/kart/gui/diffviewer.py
+++ b/kart/gui/diffviewer.py
@@ -1,43 +1,41 @@
 # -*- coding: utf-8 -*-
 
-import os
-import json
 import difflib
-
-from qgis.PyQt import uic
-from qgis.PyQt.QtCore import Qt, pyqtSignal, QCoreApplication
-from qgis.PyQt.QtGui import QColor, QBrush
-from qgis.PyQt.QtWidgets import (
-    QVBoxLayout,
-    QTableWidgetItem,
-    QHeaderView,
-    QTreeWidgetItem,
-    QDialog,
-    QTreeWidgetItemIterator,
-    QSizePolicy,
-)
+import json
+import os
 
 from qgis.core import (
-    edit,
-    QgsProject,
-    QgsFeature,
-    QgsRasterLayer,
-    QgsVectorLayer,
-    QgsJsonUtils,
-    QgsSymbol,
     Qgis,
+    QgsFeature,
     QgsGeometry,
+    QgsJsonUtils,
     QgsPointXY,
+    QgsProject,
+    QgsRasterLayer,
+    QgsSymbol,
+    QgsVectorLayer,
     QgsWkbTypes,
+    edit,
 )
-
+from qgis.gui import QgsMapCanvas, QgsMapToolPan, QgsMessageBar
+from qgis.PyQt import uic
+from qgis.PyQt.QtCore import Qt, pyqtSignal
+from qgis.PyQt.QtGui import QBrush, QColor
+from qgis.PyQt.QtWidgets import (
+    QDialog,
+    QHeaderView,
+    QSizePolicy,
+    QTableWidgetItem,
+    QTreeWidgetItem,
+    QTreeWidgetItemIterator,
+    QVBoxLayout,
+)
 from qgis.utils import iface
-from qgis.gui import QgsMapCanvas, QgsMessageBar, QgsMapToolPan
-
-from .mapswipetool import MapSwipeTool
 
 from kart.gui import icons
-from kart.utils import setting, DIFFSTYLES, tr
+from kart.utils import DIFFSTYLES, setting, tr
+
+from .mapswipetool import MapSwipeTool
 
 ADDED, MODIFIED, REMOVED, UNCHANGED = 0, 1, 2, 3
 
@@ -55,13 +53,9 @@ TAB_GEOMETRY = 1
 pluginPath = os.path.split(os.path.dirname(__file__))[0]
 
 
-pointsStyle = os.path.join(
-    pluginPath, "resources", "diff_styles", "geomdiff_points.qml"
-)
+pointsStyle = os.path.join(pluginPath, "resources", "diff_styles", "geomdiff_points.qml")
 
-WIDGET, BASE = uic.loadUiType(
-    os.path.join(os.path.dirname(__file__), "diffviewerwidget.ui")
-)
+WIDGET, BASE = uic.loadUiType(os.path.join(os.path.dirname(__file__), "diffviewerwidget.ui"))
 
 
 class DiffViewerDialog(QDialog):
@@ -94,7 +88,6 @@ class DiffViewerDialog(QDialog):
 
 
 class DiffViewerWidget(WIDGET, BASE):
-
     workingLayerChanged = pyqtSignal()
 
     def __init__(self, diff, repo, showRecoverNewButton):
@@ -307,9 +300,7 @@ class DiffViewerWidget(WIDGET, BASE):
         self.featuresTree.clear()
         for dataset, changes in self.diff.items():
             if dataset not in self.workingCopyLayerCrs:
-                self.workingCopyLayerCrs[dataset] = self.repo.workingCopyLayerCrs(
-                    dataset
-                )
+                self.workingCopyLayerCrs[dataset] = self.repo.workingCopyLayerCrs(dataset)
             crs = self.workingCopyLayerCrs[dataset]
             datasetItem = DatasetItem(dataset, crs is None)
             addedItem = QTreeWidgetItem()
@@ -365,12 +356,8 @@ class DiffViewerWidget(WIDGET, BASE):
                     geom = ref["geometry"]
                     if geom is not None:
                         geomtype = geom["type"]
-                        oldLayer = QgsVectorLayer(
-                            f"{geomtype}?crs={crs}", "old", "memory"
-                        )
-                        newLayer = QgsVectorLayer(
-                            f"{geomtype}?crs={crs}", "new", "memory"
-                        )
+                        oldLayer = QgsVectorLayer(f"{geomtype}?crs={crs}", "old", "memory")
+                        newLayer = QgsVectorLayer(f"{geomtype}?crs={crs}", "new", "memory")
                     else:
                         oldLayer = QgsVectorLayer("None", "old", "memory")
                         newLayer = QgsVectorLayer("None", "new", "memory")
@@ -406,9 +393,7 @@ class DiffViewerWidget(WIDGET, BASE):
         self.mapTool = QgsMapToolPan(self.canvas)
 
         styleName = setting(DIFFSTYLES) or "standard"
-        typeString = QgsWkbTypes.geometryDisplayString(
-            self.oldLayer.geometryType()
-        ).lower()
+        typeString = QgsWkbTypes.geometryDisplayString(self.oldLayer.geometryType()).lower()
         styleFolder = os.path.join(
             os.path.dirname(os.path.dirname(__file__)),
             "resources",
@@ -453,9 +438,7 @@ class DiffViewerWidget(WIDGET, BASE):
             self.sliderTransparency.setValue(50)
             self.setTransparency()
 
-        self.grpTransparency.setVisible(
-            self.comboDiffType.currentIndex() == TRANSPARENCY
-        )
+        self.grpTransparency.setVisible(self.comboDiffType.currentIndex() == TRANSPARENCY)
 
         self.canvas.setMapTool(self.mapTool)
         self.canvas.setLayers(layers)
@@ -495,9 +478,7 @@ class DiffViewerWidget(WIDGET, BASE):
             self.workingCopyLayers[dataset] = self.repo.workingCopyLayer(dataset)
         layer = self.workingCopyLayers[dataset]
         if dataset not in self.workingCopyLayersIdFields:
-            self.workingCopyLayersIdFields[dataset] = self.repo.workingCopyLayerIdField(
-                dataset
-            )
+            self.workingCopyLayersIdFields[dataset] = self.repo.workingCopyLayerIdField(dataset)
         crs = self.workingCopyLayerCrs[dataset]
         idField = self.workingCopyLayersIdFields[dataset]
         ref = new or old
@@ -506,12 +487,8 @@ class DiffViewerWidget(WIDGET, BASE):
         options.skipCrsValidation = True
         if refGeom is not None:
             geomtype = refGeom["type"]
-            self.oldLayer = QgsVectorLayer(
-                f"{geomtype}?crs={crs}", "old", "memory", options
-            )
-            self.newLayer = QgsVectorLayer(
-                f"{geomtype}?crs={crs}", "new", "memory", options
-            )
+            self.oldLayer = QgsVectorLayer(f"{geomtype}?crs={crs}", "old", "memory", options)
+            self.newLayer = QgsVectorLayer(f"{geomtype}?crs={crs}", "new", "memory", options)
         else:
             self.oldLayer = QgsVectorLayer("None", "old", "memory", options)
             self.newLayer = QgsVectorLayer("None", "new", "memory", options)
@@ -617,9 +594,7 @@ class DiffViewerWidget(WIDGET, BASE):
         layer = self.workingCopyLayers[self.currentFeatureItem.dataset]
         idField = self.workingCopyLayersIdFields[self.currentFeatureItem.dataset]
         with edit(layer):
-            old = list(
-                layer.getFeatures(f'"{idField}" = {self.currentFeatureItem.fid}')
-            )
+            old = list(layer.getFeatures(f'"{idField}" = {self.currentFeatureItem.fid}'))
             if old:
                 layer.deleteFeature(old[0].id())
             layer.addFeature(new)

--- a/kart/gui/dockwidget.py
+++ b/kart/gui/dockwidget.py
@@ -1,68 +1,65 @@
+import math
 import os
 import re
-import math
 import tempfile
 from functools import partial
 
+from qgis.core import (
+    Qgis,
+    QgsMimeDataUtils,
+    QgsProject,
+    QgsVectorFileWriter,
+    QgsVectorLayer,
+)
 from qgis.PyQt import uic
 from qgis.PyQt.QtCore import (
-    Qt,
-    QMimeData,
     QByteArray,
     QDataStream,
     QIODevice,
-    QCoreApplication,
+    QMimeData,
+    Qt,
 )
-
 from qgis.PyQt.QtWidgets import (
-    QDockWidget,
-    QTreeWidgetItem,
     QAbstractItemView,
-    QFileDialog,
     QAction,
-    QMenu,
-    QInputDialog,
-    QMessageBox,
     QDialog,
+    QDockWidget,
+    QFileDialog,
+    QInputDialog,
+    QMenu,
+    QMessageBox,
+    QTreeWidgetItem,
 )
-
 from qgis.utils import iface
-from qgis.core import (
-    Qgis,
-    QgsVectorLayer,
-    QgsVectorFileWriter,
-    QgsProject,
-    QgsMimeDataUtils,
-)
 
 from kart.core import RepoManager
-from kart.kartapi import (
-    Repository,
-    executeskart,
-    KartException,
-    checkKartInstalled,
-)
 from kart.gui import icons
+from kart.gui.clonedialog import CloneDialog
+from kart.gui.conflictsdialog import ConflictsDialog
+from kart.gui.dbconnectiondialog import DbConnectionDialog
 from kart.gui.diffviewer import DiffViewerDialog
 from kart.gui.historyviewer import HistoryDialog
-from kart.gui.conflictsdialog import ConflictsDialog
-from kart.gui.clonedialog import CloneDialog
-from kart.gui.pushdialog import PushDialog
-from kart.gui.pulldialog import PullDialog
 from kart.gui.initdialog import InitDialog
 from kart.gui.mergedialog import MergeDialog
-from kart.gui.switchdialog import SwitchDialog
+from kart.gui.pulldialog import PullDialog
+from kart.gui.pushdialog import PushDialog
 from kart.gui.repopropertiesdialog import RepoPropertiesDialog
-from kart.gui.dbconnectiondialog import DbConnectionDialog
+from kart.gui.switchdialog import SwitchDialog
+from kart.kartapi import (
+    KartException,
+    Repository,
+    checkKartInstalled,
+    executeskart,
+)
 from kart.utils import (
-    layerFromSource,
-    confirm,
-    setting,
-    setSetting,
     LASTREPO,
-    waitcursor,
+    confirm,
+    layerFromSource,
     progressBar,
+    setSetting,
+    setting,
     tr,
+    waitcursor,
 )
 
 pluginPath = os.path.split(os.path.dirname(__file__))[0]
@@ -203,9 +200,7 @@ class ReposItem(RefreshableItem):
         return actions
 
     def addRepo(self):
-        folder = QFileDialog.getExistingDirectory(
-            iface.mainWindow(), tr("Repository Folder"), ""
-        )
+        folder = QFileDialog.getExistingDirectory(iface.mainWindow(), tr("Repository Folder"), "")
         if folder:
             repo = Repository(folder)
             if repo.isInitialized():
@@ -257,14 +252,10 @@ class ReposItem(RefreshableItem):
             if "Writing dataset" in line:
                 datasetname = line.split(":")[-1].strip()
                 bar.setText(tr(f"Checking out layer '{datasetname}'"))
-            elif line.startswith("Receiving objects: ") or line.startswith(
-                "Writing objects: "
-            ):
+            elif line.startswith("Receiving objects: ") or line.startswith("Writing objects: "):
                 tokens = line.split(": ")
                 bar.setText(tokens[0])
-                bar.setValue(
-                    math.floor(float(tokens[1][1 : tokens[1].find("%")].strip()))
-                )
+                bar.setValue(math.floor(float(tokens[1][1 : tokens[1].find("%")].strip())))
             else:
                 msg = line.split(" - ")[-1]
                 if "%" in msg:
@@ -505,9 +496,7 @@ class RepoItem(RefreshableItem):
         if hasSchemaChanges:
             iface.messageBar().pushMessage(
                 tr("Changes"),
-                tr(
-                    "There are schema changes in the working copy and changes cannot be shown"
-                ),
+                tr("There are schema changes in the working copy and changes cannot be shown"),
                 level=Qgis.MessageLevel.Warning,
             )
             return
@@ -633,10 +622,7 @@ class RepoItem(RefreshableItem):
                 hint_text = template.format(remote=dialog.remote)
             else:
                 template = tr("Repo changes have been pushed to {remote}/{branch}")
-                hint_text = template.format(
-                    remote=dialog.remote,
-                    branch=dialog.branch
-                )
+                hint_text = template.format(remote=dialog.remote, branch=dialog.branch)
 
             iface.messageBar().pushMessage(
                 tr("Push"),
@@ -782,9 +768,7 @@ class DatasetItem(QTreeWidgetItem):
         if hasSchemaChanges:
             iface.messageBar().pushMessage(
                 tr("Changes"),
-                tr(
-                    "There are schema changes in the working copy and changes cannot be shown"
-                ),
+                tr("There are schema changes in the working copy and changes cannot be shown"),
                 level=Qgis.MessageLevel.Warning,
             )
             return
@@ -804,9 +788,7 @@ class DatasetItem(QTreeWidgetItem):
     @executeskart
     def discardChanges(self):
         if confirm(
-            tr(
-                "Are you sure you want to discard the working copy changes for this dataset?"
-            )
+            tr("Are you sure you want to discard the working copy changes for this dataset?")
         ):
             self.repo.restore("HEAD", self.name)
             iface.messageBar().pushMessage(
@@ -852,10 +834,7 @@ class DatasetItem(QTreeWidgetItem):
                 "Do you want to continue?"
             )
         else:
-            msg = tr(
-                "The dataset will be removed from the repository.\n"
-                "Do you want to continue?"
-            )
+            msg = tr("The dataset will be removed from the repository.\nDo you want to continue?")
 
         ret = QMessageBox.warning(
             iface.mainWindow(),

--- a/kart/gui/extentselectionpanel.py
+++ b/kart/gui/extentselectionpanel.py
@@ -1,29 +1,24 @@
 import os
 
-from qgis.PyQt import uic
-from qgis.PyQt.QtCore import QCoreApplication
-from qgis.PyQt.QtWidgets import (
-    QMenu,
-    QAction,
-)
-from qgis.PyQt.QtGui import QCursor
-
-from qgis.utils import iface
+from processing.gui.ExtentSelectionPanel import LayerSelectionDialog
+from processing.gui.RectangleMapTool import RectangleMapTool
 from qgis.core import (
     QgsCoordinateReferenceSystem,
     QgsProject,
     QgsRectangle,
     QgsReferencedRectangle,
 )
-
-from processing.gui.ExtentSelectionPanel import LayerSelectionDialog
-from processing.gui.RectangleMapTool import RectangleMapTool
+from qgis.PyQt import uic
+from qgis.PyQt.QtGui import QCursor
+from qgis.PyQt.QtWidgets import (
+    QAction,
+    QMenu,
+)
+from qgis.utils import iface
 
 from kart.utils import tr
 
-WIDGET, BASE = uic.loadUiType(
-    os.path.join(os.path.dirname(__file__), "extentselectionpanel.ui")
-)
+WIDGET, BASE = uic.loadUiType(os.path.join(os.path.dirname(__file__), "extentselectionpanel.ui"))
 
 
 class ExtentSelectionPanel(BASE, WIDGET):

--- a/kart/gui/featurehistorydialog.py
+++ b/kart/gui/featurehistorydialog.py
@@ -1,35 +1,31 @@
-import os
 import json
-
-from qgis.PyQt import uic
-from qgis.PyQt.QtCore import Qt, QCoreApplication
-from qgis.PyQt.QtWidgets import (
-    QHBoxLayout,
-    QTableWidgetItem,
-    QListWidgetItem,
-    QSizePolicy,
-)
-from qgis.PyQt.QtGui import QFont
+import os
 
 from qgis.core import (
-    edit,
     Qgis,
-    QgsSymbol,
-    QgsSingleSymbolRenderer,
-    QgsWkbTypes,
-    QgsProject,
     QgsJsonUtils,
+    QgsProject,
+    QgsSingleSymbolRenderer,
+    QgsSymbol,
     QgsVectorLayer,
+    QgsWkbTypes,
+    edit,
 )
 from qgis.gui import QgsMapCanvas, QgsMapToolPan, QgsMessageBar
+from qgis.PyQt import uic
+from qgis.PyQt.QtCore import Qt
+from qgis.PyQt.QtGui import QFont
+from qgis.PyQt.QtWidgets import (
+    QHBoxLayout,
+    QListWidgetItem,
+    QSizePolicy,
+    QTableWidgetItem,
+)
 from qgis.utils import iface
 
 from kart.utils import tr
 
-
-WIDGET, BASE = uic.loadUiType(
-    os.path.join(os.path.dirname(__file__), "featurehistorydialog.ui")
-)
+WIDGET, BASE = uic.loadUiType(os.path.join(os.path.dirname(__file__), "featurehistorydialog.ui"))
 
 
 class FeatureHistoryDialog(BASE, WIDGET):
@@ -118,9 +114,7 @@ class FeatureHistoryDialog(BASE, WIDGET):
         geomtype = QgsWkbTypes.displayString(geom.wkbType())
         if self.workingCopyLayerCrs is None:
             self.workingCopyLayerCrs = self.repo.workingCopyLayerCrs(self.dataset)
-        self.layer = QgsVectorLayer(
-            f"{geomtype}?crs={self.workingCopyLayerCrs}", "temp", "memory"
-        )
+        self.layer = QgsVectorLayer(f"{geomtype}?crs={self.workingCopyLayerCrs}", "temp", "memory")
         self.layer.dataProvider().addAttributes(self.workingCopyLayer.fields().toList())
         self.layer.updateFields()
         with edit(self.layer):
@@ -143,14 +137,10 @@ class FeatureHistoryDialog(BASE, WIDGET):
     def recoverVersion(self):
         new = list(self.layer.getFeatures())[0]
         if self.workingCopyLayerIdField is None:
-            self.workingCopyLayerIdField = self.repo.workingCopyLayerIdField(
-                self.dataset
-            )
+            self.workingCopyLayerIdField = self.repo.workingCopyLayerIdField(self.dataset)
         provider = self.workingCopyLayer.dataProvider()
         old = list(
-            self.workingCopyLayer.getFeatures(
-                f'"{self.workingCopyLayerIdField}" = {self.fid}'
-            )
+            self.workingCopyLayer.getFeatures(f'"{self.workingCopyLayerIdField}" = {self.fid}')
         )
         if old:
             provider.deleteFeatures([old[0].id()])
@@ -195,7 +185,7 @@ class CommitListItem(QListWidgetItem):
         self.fid = fid
         self._feature = None
         self._oldFeature = None
-        self.setText(f'{commit["message"].splitlines()[0]}')
+        self.setText(f"{commit['message'].splitlines()[0]}")
 
     def feature(self):
         self._createFeatures()

--- a/kart/gui/historyviewer.py
+++ b/kart/gui/historyviewer.py
@@ -1,47 +1,44 @@
 import json
 import os
 
-from kart.kartapi import executeskart
-from kart.gui import icons
-from kart.gui.diffviewer import DiffViewerDialog
-from kart.utils import setting, DIFFSTYLES, tr
-
 from qgis.core import Qgis, QgsProject, QgsVectorLayer, QgsWkbTypes
-from qgis.utils import iface
 from qgis.gui import QgsMessageBar
-
 from qgis.PyQt import uic
 from qgis.PyQt.QtCore import (
-    Qt,
+    QDateTime,
     QPoint,
     QRectF,
-    QDateTime,
-    QCoreApplication,
+    Qt,
 )
 from qgis.PyQt.QtGui import (
-    QPixmap,
-    QPainter,
-    QColor,
-    QPainterPath,
-    QPen,
-    QPalette,
     QBrush,
+    QColor,
+    QPainter,
+    QPainterPath,
+    QPalette,
+    QPen,
+    QPixmap,
 )
-
 from qgis.PyQt.QtWidgets import (
-    QTreeWidget,
     QAbstractItemView,
     QAction,
-    QMenu,
-    QTreeWidgetItem,
-    QWidget,
-    QVBoxLayout,
-    QSizePolicy,
-    QLabel,
-    QInputDialog,
-    QHeaderView,
     QFileDialog,
+    QHeaderView,
+    QInputDialog,
+    QLabel,
+    QMenu,
+    QSizePolicy,
+    QTreeWidget,
+    QTreeWidgetItem,
+    QVBoxLayout,
+    QWidget,
 )
+from qgis.utils import iface
+
+from kart.gui import icons
+from kart.gui.diffviewer import DiffViewerDialog
+from kart.kartapi import executeskart
+from kart.utils import DIFFSTYLES, setting, tr
 
 COMMIT_GRAPH_HEIGHT = 20
 RADIUS = 4
@@ -127,9 +124,7 @@ class HistoryTree(QTreeWidget):
                 )
             elif len(parents) > 1:
                 for parent in parents:
-                    actions[
-                        tr(f"Show diff between this commit and parent {parent[:7]}...")
-                    ] = (
+                    actions[tr(f"Show diff between this commit and parent {parent[:7]}...")] = (
                         _f(
                             self.showChangesBetweenCommits,
                             item.commit["commit"],
@@ -202,9 +197,7 @@ class HistoryTree(QTreeWidget):
 
     @executeskart
     def createTag(self, item):
-        name, ok = QInputDialog.getText(
-            self, tr("Create tag"), tr("Enter name of tag to create")
-        )
+        name, ok = QInputDialog.getText(self, tr("Create tag"), tr("Enter name of tag to create"))
         if ok and name:
             self.repo.createTag(name, item.commit["commit"])
             self.message(tr("Tag correctly created"), Qgis.MessageLevel.Info)
@@ -219,9 +212,7 @@ class HistoryTree(QTreeWidget):
     @executeskart
     def switchBranch(self, branch):
         self.repo.checkoutBranch(branch)
-        self.message(
-            tr(f"Correctly switched to branch '{branch}'"), Qgis.MessageLevel.Info
-        )
+        self.message(tr(f"Correctly switched to branch '{branch}'"), Qgis.MessageLevel.Info)
         self.populate()
 
     @executeskart
@@ -246,9 +237,7 @@ class HistoryTree(QTreeWidget):
         hasSchemaChanges = self.repo.diffHasSchemaChanges(refa, parent)
         if hasSchemaChanges:
             self.message(
-                tr(
-                    "There are schema changes in the selected commit and changes cannot be shown"
-                ),
+                tr("There are schema changes in the selected commit and changes cannot be shown"),
                 Qgis.MessageLevel.Warning,
             )
             return
@@ -297,9 +286,7 @@ class HistoryTree(QTreeWidget):
         diff = self.repo.diff(refb, refa)
         for dataset in diff:
             geojson = {"type": "FeatureCollection", "features": diff[dataset]}
-            layer = QgsVectorLayer(
-                json.dumps(geojson), f"{dataset}_diff_{refa[:7]}", "ogr"
-            )
+            layer = QgsVectorLayer(json.dumps(geojson), f"{dataset}_diff_{refa[:7]}", "ogr")
             styleName = setting(DIFFSTYLES) or "standard"
             typeString = QgsWkbTypes.geometryDisplayString(layer.geometryType()).lower()
             styleFolder = os.path.join(
@@ -315,9 +302,7 @@ class HistoryTree(QTreeWidget):
     @executeskart
     def resetBranch(self, item):
         self.repo.reset(item.commit["commit"])
-        self.message(
-            tr("Branch correctly reset to selected commit"), Qgis.MessageLevel.Info
-        )
+        self.message(tr("Branch correctly reset to selected commit"), Qgis.MessageLevel.Info)
         self.populate()
 
     @executeskart
@@ -489,7 +474,7 @@ class CommitTreeItem(QTreeWidgetItem):
                 if "HEAD ->" in label:
                     labelslist.append(
                         '<span style="background-color:crimson; color:white"> '
-                        f'&nbsp;&nbsp;{label.split("->")[-1].strip()}&nbsp;&nbsp;</span>'
+                        f"&nbsp;&nbsp;{label.split('->')[-1].strip()}&nbsp;&nbsp;</span>"
                     )
                 elif "tag:" in label:
                     labelslist.append(
@@ -516,16 +501,14 @@ class CommitTreeItem(QTreeWidgetItem):
         self.setText(5, commit["abbrevCommit"])
 
 
-WIDGET, BASE = uic.loadUiType(
-    os.path.join(os.path.dirname(__file__), "historyviewer.ui")
-)
+WIDGET, BASE = uic.loadUiType(os.path.join(os.path.dirname(__file__), "historyviewer.ui"))
+
 
 class ShallowCloneWarningItem(QTreeWidgetItem):
     def __init__(self, parent):
         QTreeWidgetItem.__init__(self, parent)
         message = tr(
-            "This repository is a shallow clone, "
-            "history past this point is not available locally"
+            "This repository is a shallow clone, history past this point is not available locally"
         )
         self.setText(2, message)
         self.setForeground(2, QBrush(QColor(100, 100, 100)))

--- a/kart/gui/initdialog.py
+++ b/kart/gui/initdialog.py
@@ -1,18 +1,15 @@
 import os
 
 from qgis.core import Qgis
-from qgis.utils import iface
 from qgis.gui import QgsMessageBar
-
 from qgis.PyQt import uic
-from qgis.PyQt.QtCore import QCoreApplication
-from qgis.PyQt.QtWidgets import QDialog, QSizePolicy, QFileDialog
+from qgis.PyQt.QtWidgets import QDialog, QFileDialog, QSizePolicy
+from qgis.utils import iface
 
 from kart.gui.locationselectionpanel import (
-    LocationSelectionPanel,
     InvalidLocationException,
+    LocationSelectionPanel,
 )
-
 from kart.utils import tr
 
 WIDGET, BASE = uic.loadUiType(os.path.join(os.path.dirname(__file__), "initdialog.ui"))
@@ -38,9 +35,7 @@ class InitDialog(BASE, WIDGET):
         self.grpLocation.layout().addWidget(self.locationPanel, 1, 0)
 
     def browse(self):
-        folder = QFileDialog.getExistingDirectory(
-            iface.mainWindow(), tr("Select Folder"), ""
-        )
+        folder = QFileDialog.getExistingDirectory(iface.mainWindow(), tr("Select Folder"), "")
         if folder:
             self.txtFolder.setText(folder)
 

--- a/kart/gui/installationwarningdialog.py
+++ b/kart/gui/installationwarningdialog.py
@@ -1,19 +1,18 @@
 import os
-import requests
 import shutil
 import subprocess
 import sys
 import tempfile
 import webbrowser
 
-from qgis.PyQt.QtWidgets import QDialog
-from qgis.PyQt.QtCore import QThread, Qt, pyqtSignal, QEventLoop
+import requests
 from qgis.PyQt import uic
-
+from qgis.PyQt.QtCore import QEventLoop, Qt, QThread, pyqtSignal
+from qgis.PyQt.QtWidgets import QDialog
 from qgis.utils import iface
 
-from kart.gui.settingsdialog import SettingsDialog
 from kart import logging
+from kart.gui.settingsdialog import SettingsDialog
 from kart.utils import tr
 
 WIDGET, BASE = uic.loadUiType(
@@ -28,7 +27,6 @@ MACOS_FILE = "Kart-{version}-macOS-{arch}.pkg"
 
 
 class DownloadAndInstallThread(QThread):
-
     downloadProgressChanged = pyqtSignal(int)
     downloadFinished = pyqtSignal()
     finished = pyqtSignal()

--- a/kart/gui/locationselectionpanel.py
+++ b/kart/gui/locationselectionpanel.py
@@ -2,12 +2,10 @@ import os
 
 from qgis.PyQt import uic
 from qgis.PyQt.QtWidgets import QWidget
+
 from kart.utils import tr
 
-
-WIDGET, BASE = uic.loadUiType(
-    os.path.join(os.path.dirname(__file__), "locationselectionpanel.ui")
-)
+WIDGET, BASE = uic.loadUiType(os.path.join(os.path.dirname(__file__), "locationselectionpanel.ui"))
 
 
 class InvalidLocationException(Exception):

--- a/kart/gui/mapswipetool.py
+++ b/kart/gui/mapswipetool.py
@@ -2,10 +2,9 @@
 # (C) 2015 by Hirofumi Hayashi and Luiz Motta
 # email: hayashi@apptec.co.jp and motta.luiz@gmail.com
 
-from qgis.PyQt.QtCore import Qt, QPoint
-from qgis.PyQt.QtGui import QCursor
-
 from qgis.gui import QgsMapTool
+from qgis.PyQt.QtCore import QPoint, Qt
+from qgis.PyQt.QtGui import QCursor
 
 from .swipemap import SwipeMap
 
@@ -68,15 +67,9 @@ class MapSwipeTool(QgsMapTool):
 
             self.swipe.setLength(e.x(), e.y())
         else:
-            length = (
-                e.x()
-                if self.swipe.isVertical
-                else self.swipe.boundingRect().height() - e.y()
-            )
+            length = e.x() if self.swipe.isVertical else self.swipe.boundingRect().height() - e.y()
             if self.swipe.length != 0 and abs(self.swipe.length - length) < THRESHOLD:
-                self.canvas().setCursor(
-                    self.cursorH if self.swipe.isVertical else self.cursorV
-                )
+                self.canvas().setCursor(self.cursorH if self.swipe.isVertical else self.cursorV)
             else:
                 self.canvas().setCursor(QCursor(Qt.CursorShape.PointingHandCursor))
 

--- a/kart/gui/mergedialog.py
+++ b/kart/gui/mergedialog.py
@@ -1,11 +1,10 @@
 import os
 
-from qgis.utils import iface
-
 from qgis.PyQt import uic
 from qgis.PyQt.QtWidgets import QDialog
-from kart.utils import tr
+from qgis.utils import iface
 
+from kart.utils import tr
 
 WIDGET, BASE = uic.loadUiType(os.path.join(os.path.dirname(__file__), "mergedialog.ui"))
 

--- a/kart/gui/pulldialog.py
+++ b/kart/gui/pulldialog.py
@@ -1,15 +1,13 @@
 import os
 
 from qgis.core import Qgis
-from qgis.utils import iface
 from qgis.gui import QgsMessageBar
-
 from qgis.PyQt import uic
-from qgis.PyQt.QtCore import QCoreApplication
 from qgis.PyQt.QtWidgets import QDialog, QSizePolicy
+from qgis.utils import iface
 
-from kart.kartapi import executeskart
 from kart.gui.remotesdialog import RemotesDialog
+from kart.kartapi import executeskart
 from kart.utils import tr
 
 pluginPath = os.path.split(os.path.dirname(__file__))[0]

--- a/kart/gui/pushdialog.py
+++ b/kart/gui/pushdialog.py
@@ -1,15 +1,13 @@
 import os
 
 from qgis.core import Qgis
-from qgis.utils import iface
 from qgis.gui import QgsMessageBar
-
 from qgis.PyQt import uic
-from qgis.PyQt.QtCore import QCoreApplication
 from qgis.PyQt.QtWidgets import QDialog, QSizePolicy
+from qgis.utils import iface
 
-from kart.kartapi import executeskart
 from kart.gui.remotesdialog import RemotesDialog
+from kart.kartapi import executeskart
 from kart.utils import tr
 
 pluginPath = os.path.split(os.path.dirname(__file__))[0]

--- a/kart/gui/remotesdialog.py
+++ b/kart/gui/remotesdialog.py
@@ -1,21 +1,17 @@
 import os
 
 from qgis.core import Qgis
-from qgis.utils import iface
 from qgis.gui import QgsMessageBar
-
 from qgis.PyQt import uic
-from qgis.PyQt.QtCore import QCoreApplication
 from qgis.PyQt.QtWidgets import QDialog, QSizePolicy
+from qgis.utils import iface
 
 from kart.kartapi import executeskart
 from kart.utils import tr
 
 pluginPath = os.path.split(os.path.dirname(__file__))[0]
 
-WIDGET, BASE = uic.loadUiType(
-    os.path.join(os.path.dirname(__file__), "remotesdialog.ui")
-)
+WIDGET, BASE = uic.loadUiType(os.path.join(os.path.dirname(__file__), "remotesdialog.ui"))
 
 
 class RemotesDialog(BASE, WIDGET):

--- a/kart/gui/repopropertiesdialog.py
+++ b/kart/gui/repopropertiesdialog.py
@@ -1,22 +1,17 @@
 import os
 
 from qgis.core import Qgis
-from qgis.utils import iface
 from qgis.gui import QgsMessageBar
-
 from qgis.PyQt import uic
-from qgis.PyQt.QtCore import QCoreApplication
 from qgis.PyQt.QtWidgets import QDialog, QSizePolicy
+from qgis.utils import iface
 
-
-from kart.layers import LayerTracker
-from kart.kartapi import executeskart
 from kart.gui.extentselectionpanel import ExtentSelectionPanel
+from kart.kartapi import executeskart
+from kart.layers import LayerTracker
 from kart.utils import tr
 
-WIDGET, BASE = uic.loadUiType(
-    os.path.join(os.path.dirname(__file__), "repopropertiesdialog.ui")
-)
+WIDGET, BASE = uic.loadUiType(os.path.join(os.path.dirname(__file__), "repopropertiesdialog.ui"))
 
 
 class RepoPropertiesDialog(BASE, WIDGET):

--- a/kart/gui/settingsdialog.py
+++ b/kart/gui/settingsdialog.py
@@ -1,24 +1,21 @@
 import os
-from qgis.utils import iface
-from qgis.gui import QgsMessageBar
 
+from qgis.gui import QgsMessageBar
 from qgis.PyQt import uic
-from qgis.PyQt.QtCore import QCoreApplication
-from qgis.PyQt.QtWidgets import QDialog, QSizePolicy, QFileDialog
+from qgis.PyQt.QtWidgets import QDialog, QFileDialog, QSizePolicy
+from qgis.utils import iface
 
 from kart.utils import (
-    setting,
-    setSetting,
-    KARTPATH,
-    HELPERMODE,
     AUTOCOMMIT,
     DIFFSTYLES,
+    HELPERMODE,
+    KARTPATH,
+    setSetting,
+    setting,
     tr,
 )
 
-WIDGET, BASE = uic.loadUiType(
-    os.path.join(os.path.dirname(__file__), "settingsdialog.ui")
-)
+WIDGET, BASE = uic.loadUiType(os.path.join(os.path.dirname(__file__), "settingsdialog.ui"))
 
 DIFF_STYLES = ["Standard", "GeoInt"]
 
@@ -50,9 +47,7 @@ class SettingsDialog(BASE, WIDGET):
         self.txtKartPath.setText(setting(KARTPATH))
 
     def browse(self, textbox):
-        folder = QFileDialog.getExistingDirectory(
-            iface.mainWindow(), tr("Select Folder"), ""
-        )
+        folder = QFileDialog.getExistingDirectory(iface.mainWindow(), tr("Select Folder"), "")
         if folder:
             textbox.setText(folder)
 

--- a/kart/gui/swipemap.py
+++ b/kart/gui/swipemap.py
@@ -2,11 +2,10 @@
 # (C) 2015 by Hirofumi Hayashi and Luiz Motta
 # email: hayashi@apptec.co.jp and motta.luiz@gmail.com
 
-from qgis.PyQt.QtCore import QRect, QLine, Qt, QSize
-from qgis.PyQt.QtGui import QColor, QImage, QPainter
-
 from qgis.core import QgsMapRendererCustomPainterJob, QgsMapSettings
 from qgis.gui import QgsMapCanvasItem
+from qgis.PyQt.QtCore import QLine, QRect, QSize, Qt
+from qgis.PyQt.QtGui import QColor, QImage, QPainter
 
 
 class SwipeMap(QgsMapCanvasItem):

--- a/kart/gui/switchdialog.py
+++ b/kart/gui/switchdialog.py
@@ -1,17 +1,15 @@
 import os
 
-from qgis.utils import iface
 from qgis.PyQt import uic
-#from qgis.PyQt.QtCore import QCoreApplication
+
+# from qgis.PyQt.QtCore import QCoreApplication
 from qgis.PyQt.QtWidgets import QInputDialog
+from qgis.utils import iface
 
 from kart.kartapi import executeskart
 from kart.utils import tr
 
-
-WIDGET, BASE = uic.loadUiType(
-    os.path.join(os.path.dirname(__file__), "switchdialog.ui")
-)
+WIDGET, BASE = uic.loadUiType(os.path.join(os.path.dirname(__file__), "switchdialog.ui"))
 
 
 class SwitchDialog(BASE, WIDGET):
@@ -19,7 +17,7 @@ class SwitchDialog(BASE, WIDGET):
         super().__init__(iface.mainWindow())
         self.repo = repo
         self.setupUi(self)
-        
+
         # Initialize translations for UI elements defined in the .ui file
         self.retranslateUi()
 

--- a/kart/gui/userconfigdialog.py
+++ b/kart/gui/userconfigdialog.py
@@ -1,21 +1,16 @@
 import os
 
 from qgis.core import Qgis
-from qgis.utils import iface
 from qgis.gui import QgsMessageBar
-
 from qgis.PyQt import uic
-from qgis.PyQt.QtCore import QCoreApplication
 from qgis.PyQt.QtWidgets import QDialog, QSizePolicy
+from qgis.utils import iface
 
 from kart.utils import tr
 
-
 pluginPath = os.path.split(os.path.dirname(__file__))[0]
 
-WIDGET, BASE = uic.loadUiType(
-    os.path.join(os.path.dirname(__file__), "userconfigdialog.ui")
-)
+WIDGET, BASE = uic.loadUiType(os.path.join(os.path.dirname(__file__), "userconfigdialog.ui"))
 
 
 class UserConfigDialog(BASE, WIDGET):
@@ -55,12 +50,7 @@ class UserConfigDialog(BASE, WIDGET):
         self.setWindowTitle(tr("User Configuration"))
         self.label.setText(tr("User name"))
         self.label_2.setText(tr("User email"))
-        html = (
-            "<html><head/><body>"
-            "<p>{line1}</p>"
-            "<p>{line2}</p>"
-            "</body></html>"
-        ).format(
+        html = ("<html><head/><body><p>{line1}</p><p>{line2}</p></body></html>").format(
             line1=tr("A user is needed to commit changes to a Kart repository."),
             line2=tr(
                 "No user is currently configured. Please configure it "

--- a/kart/kartapi.py
+++ b/kart/kartapi.py
@@ -5,37 +5,32 @@ import re
 import subprocess
 import sys
 import tempfile
-
-from typing import Optional, List, Callable
 from functools import wraps
-
+from typing import Callable, List, Optional
 from urllib.parse import urlparse
 
+from qgis.core import (
+    Qgis,
+    QgsCoordinateReferenceSystem,
+    QgsDataSourceUri,
+    QgsMessageOutput,
+    QgsProject,
+    QgsRectangle,
+    QgsReferencedRectangle,
+    QgsVectorLayer,
+)
 from qgis.PyQt.QtCore import Qt
 from qgis.PyQt.QtGui import QColor
 from qgis.PyQt.QtWidgets import (
     QApplication,
     QDialog,
 )
-
-from qgis.core import (
-    QgsDataSourceUri,
-    QgsMessageOutput,
-    QgsProject,
-    QgsCoordinateReferenceSystem,
-    QgsRectangle,
-    QgsReferencedRectangle,
-    QgsVectorLayer,
-    Qgis,
-)
 from qgis.utils import iface
 
-from kart.gui.userconfigdialog import UserConfigDialog
-from kart.gui.installationwarningdialog import InstallationWarningDialog
-
-from kart.utils import setting, setSetting, KARTPATH, HELPERMODE, tr
 from kart import logging
-
+from kart.gui.installationwarningdialog import InstallationWarningDialog
+from kart.gui.userconfigdialog import UserConfigDialog
+from kart.utils import HELPERMODE, KARTPATH, setSetting, setting, tr
 
 MINIMUM_SUPPORTED_VERSION = "0.14.0"
 CURRENT_VERSION = "0.17.0"
@@ -70,9 +65,7 @@ def executeskart(f):
                     msglines.append(line)
             errors = "<br>".join(msglines)
             if "You have uncommitted changes" in errors:
-                html_template = (
-                    "<p><b>{text}</b></p>"
-                )
+                html_template = "<p><b>{text}</b></p>"
                 msg = html_template.format(
                     text=tr(
                         "This operation requires a clean working tree. "
@@ -80,9 +73,7 @@ def executeskart(f):
                     )
                 )
             else:
-                html_template = (
-                    "<p><b>{text}</b></p><p style='color:red'>{errors}</p>"
-                )
+                html_template = "<p><b>{text}</b></p><p style='color:red'>{errors}</p>"
                 msg = html_template.format(
                     text=tr("Kart failed with the following message:"),
                     errors=errors,
@@ -113,9 +104,7 @@ def kartExecutable() -> str:
 
 def checkKartInstalled(showMessage=True, useCache=True):
     version = installedVersion(useCache)
-    supported_version_tuple = tuple(
-        int(p) for p in MINIMUM_SUPPORTED_VERSION.split(".")[:3]
-    )
+    supported_version_tuple = tuple(int(p) for p in MINIMUM_SUPPORTED_VERSION.split(".")[:3])
 
     msg = ""
     html_template = (
@@ -123,22 +112,26 @@ def checkKartInstalled(showMessage=True, useCache=True):
         "<p>{hint_text} <a href='https://kartproject.org'>https://kartproject.org</a>.</p>"
     )
 
-    hint_text = tr("Click Install to download and install the latest Kart release. You can also download releases from")
+    hint_text = tr(
+        "Click Install to download and install the latest Kart release. You can also download releases from"
+    )
 
     if version is None:
         msg = html_template.format(
-            main_text=tr("Kart is not installed or your Kart installation location is not correctly configured."),
-            hint_text=hint_text
+            main_text=tr(
+                "Kart is not installed or your Kart installation location is not correctly configured."
+            ),
+            hint_text=hint_text,
         )
     else:
         version_tuple = tuple(int(p) for p in version.split(".")[:3])
         versionOk = version_tuple >= supported_version_tuple
         if not versionOk:
             msg = html_template.format(
-                main_text=tr("The installed Kart version ({version}) is not supported by the plugin. Only versions {min_version} and later are supported.").format(
-                    version=version, min_version=MINIMUM_SUPPORTED_VERSION
-                ),
-                hint_text=hint_text
+                main_text=tr(
+                    "The installed Kart version ({version}) is not supported by the plugin. Only versions {min_version} and later are supported."
+                ).format(version=version, min_version=MINIMUM_SUPPORTED_VERSION),
+                hint_text=hint_text,
             )
 
     if msg:
@@ -183,9 +176,7 @@ def installedVersion(useCache=True):
             if not version.startswith("Kart v"):
                 raise Exception()
             else:
-                versionnum = "".join(
-                    [c for c in version.split(" ")[1] if c.isdigit() or c == "."]
-                )
+                versionnum = "".join([c for c in version.split(" ")[1] if c.isdigit() or c == "."])
                 kartVersion = versionnum
                 kartPath = path
                 return versionnum
@@ -580,8 +571,7 @@ class Repository:
         ret = self.executeKart(commands, True)
         changes = list(ret.values())[0]
         schemaChanges = list(
-            changes.get(name, {}).get("meta", {}).get("schema.json", None)
-            for name in changes
+            changes.get(name, {}).get("meta", {}).get("schema.json", None) for name in changes
         )
         return any(s is not None for s in schemaChanges)
 
@@ -746,9 +736,9 @@ class Repository:
             return layer
 
     def workingCopyLayerIdField(self, dataset):
-        schema = self.executeKart(["meta", "get", dataset, "schema.json"], True)[
-            dataset
-        ]["schema.json"]
+        schema = self.executeKart(["meta", "get", dataset, "schema.json"], True)[dataset][
+            "schema.json"
+        ]
         for attr in schema:
             if attr.get("primaryKeyIndex") == 0:
                 return attr["name"]

--- a/kart/layers.py
+++ b/kart/layers.py
@@ -1,35 +1,34 @@
 import os
 from functools import partial
 
-from qgis.utils import iface
 from qgis.core import (
     Qgis,
-    QgsMapLayer,
-    QgsVectorLayer,
-    QgsFeatureRequest,
-    QgsRectangle,
-    QgsWkbTypes,
     QgsCoordinateTransform,
-    QgsProject,
+    QgsFeatureRequest,
+    QgsFillSymbol,
     QgsGeometry,
-    QgsTextAnnotation,
+    QgsMapLayer,
     QgsMarkerSymbol,
     QgsPointXY,
-    QgsFillSymbol,
+    QgsProject,
+    QgsRectangle,
+    QgsTextAnnotation,
+    QgsVectorLayer,
+    QgsWkbTypes,
 )
 from qgis.gui import QgsMapToolEmitPoint, QgsRubberBand
-
-from qgis.PyQt.QtCore import Qt, QSizeF, QPointF
+from qgis.PyQt.QtCore import QPointF, QSizeF, Qt
 from qgis.PyQt.QtGui import QColor, QTextDocument
 from qgis.PyQt.QtWidgets import QAction, QInputDialog
+from qgis.utils import iface
 
+from kart.core import RepoManager
 from kart.gui import icons
-from kart.gui.historyviewer import HistoryDialog
 from kart.gui.diffviewer import DiffViewerDialog
 from kart.gui.featurehistorydialog import FeatureHistoryDialog
+from kart.gui.historyviewer import HistoryDialog
 from kart.kartapi import executeskart
-from kart.utils import setting, AUTOCOMMIT, tr
-from kart.core import RepoManager
+from kart.utils import AUTOCOMMIT, setting, tr
 
 
 def _f(f, *args):
@@ -40,7 +39,6 @@ def _f(f, *args):
 
 
 class LayerTracker:
-
     __instance = None
 
     @staticmethod
@@ -71,9 +69,7 @@ class LayerTracker:
         self.showWorkingTreeChangesAction = QAction(
             icons.diffIcon, tr("Show working copy changes..."), iface
         )
-        self.showWorkingTreeChangesAction.triggered.connect(
-            _f(self.showWorkingTreeChanges)
-        )
+        self.showWorkingTreeChangesAction.triggered.connect(_f(self.showWorkingTreeChanges))
         iface.addCustomActionForLayerType(
             self.showWorkingTreeChangesAction,
             "Kart",
@@ -84,9 +80,7 @@ class LayerTracker:
         self.discardWorkingTreeChangesAction = QAction(
             icons.discardIcon, tr("Discard working copy changes..."), iface
         )
-        self.discardWorkingTreeChangesAction.triggered.connect(
-            _f(self.discardWorkingTreeChanges)
-        )
+        self.discardWorkingTreeChangesAction.triggered.connect(_f(self.discardWorkingTreeChanges))
         iface.addCustomActionForLayerType(
             self.discardWorkingTreeChangesAction,
             "Kart",
@@ -97,9 +91,7 @@ class LayerTracker:
         self.commitWorkingTreeChangesAction = QAction(
             icons.commitIcon, tr("Commit working copy changes..."), iface
         )
-        self.commitWorkingTreeChangesAction.triggered.connect(
-            _f(self.commitWorkingTreeChanges)
-        )
+        self.commitWorkingTreeChangesAction.triggered.connect(_f(self.commitWorkingTreeChanges))
         iface.addCustomActionForLayerType(
             self.commitWorkingTreeChangesAction,
             "Kart",
@@ -141,12 +133,8 @@ class LayerTracker:
                 self.connected[layer] = func
                 iface.addCustomActionForLayer(self.showLogAction, layer)
                 iface.addCustomActionForLayer(self.showWorkingTreeChangesAction, layer)
-                iface.addCustomActionForLayer(
-                    self.commitWorkingTreeChangesAction, layer
-                )
-                iface.addCustomActionForLayer(
-                    self.discardWorkingTreeChangesAction, layer
-                )
+                iface.addCustomActionForLayer(self.commitWorkingTreeChangesAction, layer)
+                iface.addCustomActionForLayer(self.discardWorkingTreeChangesAction, layer)
                 if layer.wkbType() != QgsWkbTypes.Type.NoGeometry:
                     iface.addCustomActionForLayer(self.setMapToolAction, layer)
 
@@ -180,9 +168,7 @@ class LayerTracker:
         annotation.setMarkerSymbol(symbol)
         annotation.setObjectName(f"kart:{layer.id()}")
         PT_MM = 25.4 / 72.0
-        annotation.setFrameOffsetFromReferencePointMm(
-            QPointF(-doc.size().width() * PT_MM, -5)
-        )
+        annotation.setFrameOffsetFromReferencePointMm(QPointF(-doc.size().width() * PT_MM, -5))
         QgsProject.instance().annotationManager().addAnnotation(annotation)
 
     def updateRubberBands(self):
@@ -224,9 +210,7 @@ class LayerTracker:
                 annotation, QgsTextAnnotation
             ) and annotation.document().toPlainText().startswith("kart:"):
                 try:
-                    QgsProject.instance().annotationManager().removeAnnotation(
-                        annotation
-                    )
+                    QgsProject.instance().annotationManager().removeAnnotation(annotation)
                 except Exception:
                     pass
 
@@ -244,9 +228,7 @@ class LayerTracker:
         r = self.mapTool.toLayerCoordinates(self.mapToolLayer, r)
 
         feats = self.mapToolLayer.getFeatures(
-            QgsFeatureRequest()
-            .setFilterRect(r)
-            .setFlags(QgsFeatureRequest.Flag.ExactIntersect)
+            QgsFeatureRequest().setFilterRect(r).setFlags(QgsFeatureRequest.Flag.ExactIntersect)
         )
         dataset = self.mapToolRepo.datasetNameFromLayer(self.mapToolLayer)
         idField = self.mapToolRepo.workingCopyLayerIdField(dataset)
@@ -254,9 +236,7 @@ class LayerTracker:
             feature = next(feats)
             fid = feature[idField]
             history = self.mapToolRepo.log(dataset=dataset, featureid=fid)
-            dlg = FeatureHistoryDialog(
-                history, self.mapToolLayer, dataset, fid, self.mapToolRepo
-            )
+            dlg = FeatureHistoryDialog(history, self.mapToolLayer, dataset, fid, self.mapToolRepo)
             dlg.exec()
         except StopIteration:
             iface.messageBar().pushMessage(

--- a/kart/logging.py
+++ b/kart/logging.py
@@ -1,4 +1,4 @@
-from qgis.core import QgsMessageLog, Qgis
+from qgis.core import Qgis, QgsMessageLog
 
 DEBUG = True
 MAX_LINES = 20

--- a/kart/plugin.py
+++ b/kart/plugin.py
@@ -2,9 +2,8 @@ import configparser
 import os
 import platform
 
-from qgis.core import QgsApplication, QgsProject, Qgis, QgsMessageOutput
-
-from qgis.PyQt.QtCore import Qt, QCoreApplication, QSettings, QTranslator
+from qgis.core import Qgis, QgsApplication, QgsMessageOutput, QgsProject
+from qgis.PyQt.QtCore import QCoreApplication, QSettings, Qt, QTranslator
 from qgis.PyQt.QtWidgets import QAction
 
 from kart.gui.dockwidget import KartDockWidget
@@ -36,7 +35,6 @@ class KartPlugin(object):
         QgsApplication.processingRegistry().addProvider(self.provider)
 
     def initGui(self):
-
         self.dock = KartDockWidget()
         self.iface.addDockWidget(Qt.DockWidgetArea.RightDockWidgetArea, self.dock)
 

--- a/kart/processing/__init__.py
+++ b/kart/processing/__init__.py
@@ -11,7 +11,6 @@ from .tags import RepoCreateTag
 
 class KartProvider(QgsProcessingProvider):
     def loadAlgorithms(self, *args, **kwargs):
-
         self.addAlgorithm(RepoInit())
         self.addAlgorithm(RepoClone())
         self.addAlgorithm(RepoCreateTag())

--- a/kart/processing/base.py
+++ b/kart/processing/base.py
@@ -1,4 +1,3 @@
-from qgis.PyQt.QtCore import QCoreApplication
 from qgis.core import QgsProcessingAlgorithm
 
 

--- a/kart/processing/branches.py
+++ b/kart/processing/branches.py
@@ -1,8 +1,9 @@
 from qgis.core import QgsProcessingParameterFile, QgsProcessingParameterString
+
 from kart.gui import icons
+from kart.utils import tr
 
 from .base import KartAlgorithm
-from kart.utils import tr
 
 
 class RepoCreateBranch(KartAlgorithm):
@@ -19,7 +20,6 @@ class RepoCreateBranch(KartAlgorithm):
         return icons.createBranchIcon
 
     def initAlgorithm(self, config=None):
-
         self.addParameter(
             QgsProcessingParameterFile(
                 self.REPO_PATH,
@@ -63,7 +63,6 @@ class RepoSwitchBranch(KartAlgorithm):
         return icons.checkoutIcon
 
     def initAlgorithm(self, config=None):
-
         self.addParameter(
             QgsProcessingParameterFile(
                 self.REPO_PATH,
@@ -107,7 +106,6 @@ class RepoDeleteBranch(KartAlgorithm):
         return icons.deleteIcon
 
     def initAlgorithm(self, config=None):
-
         self.addParameter(
             QgsProcessingParameterFile(
                 self.REPO_PATH,

--- a/kart/processing/data.py
+++ b/kart/processing/data.py
@@ -1,12 +1,13 @@
 from qgis.core import (
+    QgsProcessingOutputFolder,
     QgsProcessingParameterFile,
     QgsProcessingParameterString,
-    QgsProcessingOutputFolder,
 )
+
 from kart.gui import icons
+from kart.utils import tr
 
 from .base import KartAlgorithm
-from kart.utils import tr
 
 
 class RepoImportData(KartAlgorithm):
@@ -24,7 +25,6 @@ class RepoImportData(KartAlgorithm):
         return icons.importIcon
 
     def initAlgorithm(self, config=None):
-
         self.addParameter(
             QgsProcessingParameterFile(
                 self.REPO_PATH,
@@ -61,9 +61,7 @@ class RepoImportData(KartAlgorithm):
 
         repo_path = self.parameterAsFile(parameters, self.REPO_PATH, context)
         data_path = self.parameterAsFile(parameters, self.REPO_DATA_PATH, context)
-        dataset_name = self.parameterAsString(
-            parameters, self.REPO_DATASET_NAME, context
-        )
+        dataset_name = self.parameterAsString(parameters, self.REPO_DATASET_NAME, context)
 
         repo = Repository(repo_path)
         repo.importIntoRepo(data_path, dataset_name)

--- a/kart/processing/remotes.py
+++ b/kart/processing/remotes.py
@@ -1,8 +1,9 @@
 from qgis.core import QgsProcessingParameterFile, QgsProcessingParameterString
+
 from kart.gui import icons
+from kart.utils import tr
 
 from .base import KartAlgorithm
-from kart.utils import tr
 
 
 class RepoPushToRemote(KartAlgorithm):
@@ -20,7 +21,6 @@ class RepoPushToRemote(KartAlgorithm):
         return icons.pushIcon
 
     def initAlgorithm(self, config=None):
-
         self.addParameter(
             QgsProcessingParameterFile(
                 self.REPO_PATH,
@@ -74,7 +74,6 @@ class RepoPullFromRemote(KartAlgorithm):
         return icons.pullIcon
 
     def initAlgorithm(self, config=None):
-
         self.addParameter(
             QgsProcessingParameterFile(
                 self.REPO_PATH,

--- a/kart/processing/repos.py
+++ b/kart/processing/repos.py
@@ -1,18 +1,19 @@
 from qgis.core import (
     QgsProcessingContext,
-    QgsProcessingParameterFile,
+    QgsProcessingOutputMultipleLayers,
     QgsProcessingParameterBoolean,
+    QgsProcessingParameterExtent,
+    QgsProcessingParameterFile,
+    QgsProcessingParameterFolderDestination,
     QgsProcessingParameterNumber,
     QgsProcessingParameterString,
-    QgsProcessingParameterExtent,
-    QgsProcessingParameterFolderDestination,
-    QgsProcessingOutputMultipleLayers,
     QgsReferencedRectangle,
 )
+
 from kart.gui import icons
+from kart.utils import tr
 
 from .base import KartAlgorithm
-from kart.utils import tr
 
 
 class RepoInit(KartAlgorithm):
@@ -28,7 +29,6 @@ class RepoInit(KartAlgorithm):
         return icons.createRepoIcon
 
     def initAlgorithm(self, config=None):
-
         self.addParameter(
             QgsProcessingParameterFile(
                 self.REPO_PATH,
@@ -67,7 +67,6 @@ class RepoClone(KartAlgorithm):
         return icons.cloneRepoIcon
 
     def initAlgorithm(self, config=None):
-
         self.addParameter(
             QgsProcessingParameterString(
                 self.REPO_CLONE_URL,
@@ -102,15 +101,11 @@ class RepoClone(KartAlgorithm):
         )
 
         self.addParameter(
-            QgsProcessingParameterFolderDestination(
-                self.REPO_OUTPUT_FOLDER, tr("Output folder")
-            )
+            QgsProcessingParameterFolderDestination(self.REPO_OUTPUT_FOLDER, tr("Output folder"))
         )
 
         self.addParameter(
-            QgsProcessingParameterBoolean(
-                self.REPO_ADD_TO_MAP, tr("Add layers to the Map")
-            )
+            QgsProcessingParameterBoolean(self.REPO_ADD_TO_MAP, tr("Add layers to the Map"))
         )
 
         self.addOutput(
@@ -130,9 +125,7 @@ class RepoClone(KartAlgorithm):
         add_layers = self.parameterAsBool(parameters, self.REPO_ADD_TO_MAP, context)
 
         extent_rect = self.parameterAsExtent(parameters, self.REPO_CLONE_DEPTH, context)
-        extent_crs = self.parameterAsExtentCrs(
-            parameters, self.REPO_CLONE_SPATIAL_EXTENT, context
-        )
+        extent_crs = self.parameterAsExtentCrs(parameters, self.REPO_CLONE_SPATIAL_EXTENT, context)
         extent = None
         if parameters.get(self.REPO_CLONE_SPATIAL_EXTENT):
             extent = QgsReferencedRectangle(extent_rect, extent_crs)
@@ -150,9 +143,7 @@ class RepoClone(KartAlgorithm):
 
         if add_layers:
             for layer in layers:
-                context.addLayerToLoadOnCompletion(
-                    layer.id(), QgsProcessingContext.LayerDetails()
-                )
+                context.addLayerToLoadOnCompletion(layer.id(), QgsProcessingContext.LayerDetails())
 
         return {
             self.REPO_OUTPUT_FOLDER: folder,

--- a/kart/processing/tags.py
+++ b/kart/processing/tags.py
@@ -1,8 +1,9 @@
 from qgis.core import QgsProcessingParameterFile, QgsProcessingParameterString
+
 from kart.gui import icons
+from kart.utils import tr
 
 from .base import KartAlgorithm
-from kart.utils import tr
 
 
 class RepoCreateTag(KartAlgorithm):
@@ -19,7 +20,6 @@ class RepoCreateTag(KartAlgorithm):
         return icons.propertiesIcon
 
     def initAlgorithm(self, config=None):
-
         self.addParameter(
             QgsProcessingParameterFile(
                 self.REPO_PATH,

--- a/kart/tests/test_kartapi.py
+++ b/kart/tests/test_kartapi.py
@@ -4,29 +4,27 @@ import shutil
 import tempfile
 
 from qgis.core import (
-    edit,
-    QgsRectangle,
-    QgsReferencedRectangle,
     QgsCoordinateReferenceSystem,
     QgsFeature,
     QgsGeometry,
     QgsPointXY,
+    QgsRectangle,
+    QgsReferencedRectangle,
+    edit,
 )
-from qgis.testing import unittest, start_app
-
 from qgis.PyQt.QtTest import QSignalSpy
+from qgis.testing import start_app, unittest
 
-from kart.kartapi import (
-    kartVersionDetails,
-    Repository,
-    installedVersion,
-    KartException,
-    executeKart,
-)
 from kart.core import RepoManager
-
-from kart.utils import HELPERMODE, setSetting, KARTPATH
+from kart.kartapi import (
+    KartException,
+    Repository,
+    executeKart,
+    installedVersion,
+    kartVersionDetails,
+)
 from kart.tests.utils import patch_iface
+from kart.utils import HELPERMODE, KARTPATH, setSetting
 
 start_app()
 
@@ -65,7 +63,7 @@ class TestKartapi(unittest.TestCase):
     def testEnableUseHelper(self):
         setSetting(HELPERMODE, True)
         kartVersionDetails()  # called to set up environment var
-        assert executeKart.env['KART_USE_HELPER'] == '1', "Helper mode was not enabled"
+        assert executeKart.env["KART_USE_HELPER"] == "1", "Helper mode was not enabled"
 
     def testChangeHelperMode(self):
         """
@@ -76,11 +74,11 @@ class TestKartapi(unittest.TestCase):
         kartVersionDetails()  # called to set up environment var
         setSetting(HELPERMODE, False)
         kartVersionDetails()  # called to set up environment var
-        assert executeKart.env['KART_USE_HELPER'] == '', "Helper mode was not disabled"
+        assert executeKart.env["KART_USE_HELPER"] == "", "Helper mode was not disabled"
 
     def testKartVersion(self):
         version = installedVersion()
-        assert re.match(r'\d+\.\d+\.\d+', version)
+        assert re.match(r"\d+\.\d+\.\d+", version)
 
     def testStoreReposInSettings(self):
         manager = RepoManager()
@@ -121,9 +119,7 @@ class TestKartapi(unittest.TestCase):
             repo.init()
             assert repo.isInitialized()
             repo.configureUser("user", "user@user.use")
-            gkpgPath = os.path.join(
-                os.path.dirname(__file__), "data", "layers", "testlayer.gpkg"
-            )
+            gkpgPath = os.path.join(os.path.dirname(__file__), "data", "layers", "testlayer.gpkg")
             repo.importIntoRepo(gkpgPath)
             vectorLayers, tables = repo.datasets()
             assert vectorLayers == ["testlayer"]

--- a/kart/utils.py
+++ b/kart/utils.py
@@ -1,18 +1,14 @@
 import os
-
-from qgis.PyQt.QtCore import (
-    Qt,
-    QCoreApplication,
-    QSettings,
-    QTranslator,
-    QT_TRANSLATE_NOOP,
-)
-from qgis.PyQt.QtWidgets import QProgressBar, QLabel, QMessageBox, QApplication
-from qgis.core import QgsProject, Qgis
-from qgis.utils import iface as qgisiface
-
 from contextlib import contextmanager
 
+from qgis.core import Qgis, QgsProject
+from qgis.PyQt.QtCore import (
+    QCoreApplication,
+    QSettings,
+    Qt,
+)
+from qgis.PyQt.QtWidgets import QApplication, QLabel, QMessageBox, QProgressBar
+from qgis.utils import iface as qgisiface
 
 # This can be further patched using the test.utils module
 iface = qgisiface
@@ -37,9 +33,7 @@ class ProgressBar:
         self.progress = QProgressBar()
         self.progress.setRange(0, 100)
         self.progress.setValue(0)
-        self.progress.setAlignment(
-            Qt.AlignmentFlag.AlignLeft | Qt.AlignmentFlag.AlignVCenter
-        )
+        self.progress.setAlignment(Qt.AlignmentFlag.AlignLeft | Qt.AlignmentFlag.AlignVCenter)
         self.progressMessageBar.layout().addWidget(self.progress)
         iface.messageBar().pushWidget(self.progressMessageBar, Qgis.MessageLevel.Info)
         QCoreApplication.processEvents()
@@ -112,7 +106,7 @@ def setSetting(name, value):
 
 def setting(name):
     v = QSettings().value(f"{NAMESPACE}/{name}", None)
-    if setting_types.get(name, str) == bool:
+    if setting_types.get(name, str) is bool:
         return str(v).lower() == str(True).lower()
     else:
         return v

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,10 @@
+[tool.ruff]
+line-length = 99
+extend-exclude = ["helper.py"]
+
+[tool.ruff.lint]
+# Default ruff rules are a subset of flake8 (E4, E7, E9, F). Keep it close to
+# the previous flake8 config so this swap doesn't broaden scope.
+# "I" enables ruff's isort-equivalent import sorting.
+extend-select = ["I"]
+extend-ignore = ["E203"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,0 @@
-[flake8]
-extend-ignore = E203
-max-line-length = 99
-exclude = helper.py
-
-[isort]
-profile = black


### PR DESCRIPTION
## Summary
- Replace flake8+black+isort with ruff (both `check` and `format`)
- Pre-commit uses a custom `.hooks/kx-ruff.py` script  that runs `ruff check --fix` and `ruff format` and re-stages the changes
- CI pins the same ruff version so local and CI stay in sync
- Drop dead `setup.cfg` (isort was configured but never wired up); flake8 options move to `pyproject.toml`. Ruff's `I` rules cover isort

## Test plan
- [x] `pre-commit run --all-files` passes locally
- [x] CI lint job passes
