### PR TITLE
fix feature inspection issues in history dialog 

### DIFF
--- a/kart/gui/featurehistorydialog.py
+++ b/kart/gui/featurehistorydialog.py
@@ -72,7 +72,7 @@ class FeatureHistoryDialog(BASE, WIDGET):
         row = self.listCommits.currentRow()
         if row == self.listCommits.count() - 1:
             if self.listCommits.count() == 1:
-                return
+                return self.listCommits.currentItem().feature()
             else:
                 return self.listCommits.item(row - 1).oldFeature()
         else:

--- a/kart/layers.py
+++ b/kart/layers.py
@@ -225,7 +225,8 @@ class LayerTracker:
         searchRadius = iface.mapCanvas().extent().width() * 0.005
         r = QgsRectangle(pt, pt)
         r.grow(searchRadius)
-        r = self.mapTool.toLayerCoordinates(self.mapToolLayer, r)
+        if self.mapToolLayer and self.mapToolLayer.isValid():
+            r = self.mapTool.toLayerCoordinates(self.mapToolLayer, r)
 
         feats = self.mapToolLayer.getFeatures(
             QgsFeatureRequest().setFilterRect(r).setFlags(QgsFeatureRequest.Flag.ExactIntersect)


### PR DESCRIPTION
This PR fixes two issues in the feature inspection workflow:

- Allow Feature History dialog to show attributes for single-commit features
- Map click inspection could fail or crash when no valid layer was active or when CRS mismatches affected spatial queries.

**Changes**
FeatureHistoryDialog

- Fixed logic in _currentCommitFeature to return the current feature when history contains only one commit.
- Ensures attribute data is displayed for newly created / single-history features.

Map Tool / Layer Inspection

- Added defensive validation for active map tool layer before inspection.