### PR TITLE
WIP: feat: add attachment file tracking and QGIS project sync to Kart plugin

### DIFF
--- a/kart/gui/dockwidget.py
+++ b/kart/gui/dockwidget.py
@@ -12,10 +12,12 @@ from qgis.core import (
     QgsVectorLayer,
 )
 from qgis.gui import QgsDockWidget
+from qgis.PyQt.QtGui import QBrush, QColor
 from qgis.PyQt import uic
 from qgis.PyQt.QtCore import (
     QByteArray,
     QDataStream,
+    QEvent,
     QIODevice,
     QMimeData,
     Qt,
@@ -24,13 +26,20 @@ from qgis.PyQt.QtWidgets import (
     QAbstractItemView,
     QAction,
     QDialog,
+    QDialogButtonBox,
     QFileDialog,
+    QFrame,
     QInputDialog,
+    QLabel,
     QMenu,
     QMessageBox,
+    QPushButton,
+    QTextEdit,
     QTreeWidgetItem,
+    QVBoxLayout,
 )
 from qgis.utils import iface
+from qgis.core import QgsApplication
 
 from kart.core import RepoManager
 from kart.gui import icons
@@ -52,7 +61,11 @@ from kart.kartapi import (
     executeskart,
 )
 from kart.utils import (
+    AUTO_COMMIT_ON_SAVE,
+    AUTO_PUSH,
     LASTREPO,
+    WARN_ON_EXIT_UNCOMMITTED,
+    WARN_ON_EXIT_UNPUSHED,
     confirm,
     layerFromSource,
     progressBar,
@@ -63,6 +76,17 @@ from kart.utils import (
 )
 
 pluginPath = os.path.split(os.path.dirname(__file__))[0]
+
+PROJECT_MARKER_PREFIX = "kart_plugin_loaded_qgs"
+
+
+def project_tracking_keys():
+    return (
+        f"{PROJECT_MARKER_PREFIX}_repo_path",
+        f"{PROJECT_MARKER_PREFIX}_rel_path",
+        f"{PROJECT_MARKER_PREFIX}_blob_hash",
+    )
+
 
 WIDGET, BASE = uic.loadUiType(os.path.join(os.path.dirname(__file__), "dockwidget.ui"))
 
@@ -118,6 +142,17 @@ class KartDockWidget(QgsDockWidget, WIDGET):
 
         self.fillTree()
 
+        self.btnSaveProjectToKart = QPushButton(tr("Save project to Kart"), self)
+        self.btnSaveProjectToKart.setToolTip(
+            tr("Save the current dirty QGIS project as a diffable .qgs file in Kart")
+        )
+        self.btnSaveProjectToKart.clicked.connect(self.saveProjectToKartFromButton)
+        self.verticalLayout.insertWidget(1, self.btnSaveProjectToKart)
+        self.tree.currentItemChanged.connect(lambda *args: self.updateSaveProjectButton())
+        self._installProjectDirtyHooks()
+        self._installSaveShortcutFilter()
+        self.updateSaveProjectButton()
+
     def fillTree(self):
         self.tree.clear()
         self.reposItem = ReposItem()
@@ -163,6 +198,314 @@ class KartDockWidget(QgsDockWidget, WIDGET):
 
         self.setWindowTitle(tr("Kart repositories"))
         self.label_2.setText(tr("Tip: right-click on items for available actions"))
+
+    def updateSaveProjectButton(self):
+        project = QgsProject.instance()
+        info = self._activeProjectInfo()
+        self.btnSaveProjectToKart.setVisible(info is not None)
+        self.btnSaveProjectToKart.setEnabled(info is not None and project.isDirty())
+
+    def saveProjectToKartFromButton(self):
+        repo_item = self._repoItemForActiveProject()
+        if repo_item is not None:
+            repo_item.saveProjectToRepo()
+
+    def _installProjectDirtyHooks(self):
+        project = QgsProject.instance()
+        for signal_name in ("isDirtyChanged", "readProject", "cleared"):
+            signal = getattr(project, signal_name, None)
+            if signal is None:
+                continue
+            try:
+                signal.connect(lambda *args: self.updateSaveProjectButton())
+            except Exception:
+                pass
+        readProject = getattr(project, "readProject", None)
+        if readProject is not None:
+            try:
+                readProject.connect(self._onProjectRead)
+            except Exception:
+                pass
+        cleared = getattr(project, "cleared", None)
+        if cleared is not None:
+            try:
+                cleared.connect(self._onProjectCleared)
+            except Exception:
+                pass
+        projectSaved = getattr(project, "projectSaved", None)
+        if projectSaved is not None:
+            try:
+                projectSaved.connect(self._onProjectSaved)
+            except Exception:
+                pass
+        isDirtyChanged = getattr(project, "isDirtyChanged", None)
+        if isDirtyChanged is not None:
+            try:
+                isDirtyChanged.connect(self._onProjectDirtyChanged)
+            except Exception:
+                pass
+
+    def _onProjectCleared(self, *args):
+        project = QgsProject.instance()
+        repo_key, path_key, hash_key = project_tracking_keys()
+        for key in (repo_key, path_key, hash_key):
+            try:
+                project.setProperty(key, None)
+            except Exception:
+                pass
+        self.updateSaveProjectButton()
+
+    def _onProjectDirtyChanged(self, *args):
+        repo_item = self._repoItemForActiveProject() or self._currentRepoItem()
+        if repo_item is None:
+            return
+        try:
+            if hasattr(repo_item, "filesItem") and repo_item.filesItem is not None:
+                repo_item.filesItem.refreshContent()
+            repo_item.setTitle()
+        except Exception:
+            pass
+
+    def _onProjectSaved(self, *args):
+        repo_item = self._repoItemForActiveProject()
+        if repo_item is None:
+            return
+        try:
+            if hasattr(repo_item, "filesItem") and repo_item.filesItem is not None:
+                repo_item.filesItem.refreshContent()
+        except Exception:
+            pass
+
+    def _onProjectRead(self, *args):
+        """Auto-detect .qgs files opened from a Kart working copy."""
+        project = QgsProject.instance()
+        project_path = project.fileName()
+        if not project_path:
+            return
+        for i in range(self.reposItem.childCount() if hasattr(self, "reposItem") else 0):
+            item = self.reposItem.child(i)
+            if not isinstance(item, RepoItem):
+                continue
+            if item.repo.pathInsideRepo(project_path):
+                rel_path = item.repo.repoRelativePath(project_path)
+                self._setLoadedProjectMarker(item.repo.path, rel_path)
+                self.updateSaveProjectButton()
+                return
+
+    def _installSaveShortcutFilter(self):
+        try:
+            from qgis.utils import iface as _iface
+            main_win = _iface.mainWindow()
+            if main_win is not None:
+                main_win.installEventFilter(self)
+        except Exception:
+            pass
+
+    def cleanup(self):
+        try:
+            from qgis.utils import iface as _iface
+            main_win = _iface.mainWindow()
+            if main_win is not None:
+                main_win.removeEventFilter(self)
+        except Exception:
+            pass
+
+    def eventFilter(self, obj, event):
+        if event.type() == QEvent.Close and obj is iface.mainWindow():
+            self._onMainWindowClose()
+        if (
+            event.type() == QEvent.KeyPress
+            and setting(AUTO_COMMIT_ON_SAVE)
+        ):
+            from qgis.PyQt.QtCore import Qt as _Qt
+            key = event.key()
+            mods = event.modifiers()
+            if key == _Qt.Key_S and (mods & _Qt.ControlModifier):
+                repo_item = self._repoItemForProjectSave()
+                if repo_item is not None:
+                    event.accept()
+                    repo_item.saveProjectToRepo()
+                    return True
+        return super().eventFilter(obj, event)
+
+    def _onMainWindowClose(self):
+        """Prompt on exit for unsaved QGIS project changes and uncommitted Kart changes."""
+        # 1. Unsaved QGIS project tracked in Kart
+        project = QgsProject.instance()
+        if project.isDirty():
+            info = self._activeProjectInfo()
+            if info:
+                repo_path, rel_path, _blob_hash = info
+                repo_item = self._repoItemForPath(repo_path)
+                if repo_item is not None:
+                    reply = QMessageBox.question(
+                        iface.mainWindow(),
+                        tr("Save QGIS project to Kart"),
+                        tr(
+                            "The QGIS project '{rel_path}' has unsaved changes and is tracked in a "
+                            "Kart repository.\n\nSave it to the Kart repository before quitting?"
+                        ).format(rel_path=rel_path),
+                        QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
+                        QMessageBox.StandardButton.No,
+                    )
+                    if reply == QMessageBox.StandardButton.Yes:
+                        try:
+                            repo_item.saveProjectToRepo()
+                        except Exception:
+                            pass
+
+        # 2. Uncommitted or unpushed Kart changes
+        warn_uncommitted = setting(WARN_ON_EXIT_UNCOMMITTED)
+        warn_unpushed = setting(WARN_ON_EXIT_UNPUSHED)
+        if not warn_uncommitted and not warn_unpushed:
+            return
+        if not hasattr(self, "reposItem"):
+            return
+        uncommitted_repos = []
+        unpushed_repos = []
+        for i in range(self.reposItem.childCount()):
+            item = self.reposItem.child(i)
+            if not isinstance(item, RepoItem):
+                continue
+            try:
+                is_clean = item.repo.isWorkingTreeClean()
+                if warn_uncommitted and not is_clean:
+                    uncommitted_repos.append(item.repo.title() or os.path.normpath(item.repo.path))
+                if warn_unpushed:
+                    ahead, _ = item.repo.aheadBehind()
+                    if ahead:
+                        unpushed_repos.append(item.repo.title() or os.path.normpath(item.repo.path))
+            except Exception:
+                pass
+        if not uncommitted_repos and not unpushed_repos:
+            return
+        parts = []
+        if uncommitted_repos:
+            names = "\n".join(f"  • {r}" for r in uncommitted_repos)
+            parts.append(f"Uncommitted changes:\n{names}")
+        if unpushed_repos:
+            names = "\n".join(f"  • {r}" for r in unpushed_repos)
+            parts.append(f"Unpushed commits:\n{names}")
+        QMessageBox.warning(
+            iface.mainWindow(),
+            tr("Unsynchronised Kart changes"),
+            "\n\n".join(parts) + "\n\n" + tr("Make sure to commit and push before quitting."),
+        )
+
+    def _activeProjectInfo(self):
+        repo_key, path_key, hash_key = project_tracking_keys()
+        project = QgsProject.instance()
+        repo_path = project.readEntry(repo_key, "/")[0] or None
+        rel_path = project.readEntry(path_key, "/")[0] or None
+        blob_hash = project.readEntry(hash_key, "/")[0] or None
+        if repo_path and rel_path:
+            return repo_path, rel_path, blob_hash
+        return None
+
+    def _repoItemForPath(self, repo_path):
+        if not hasattr(self, "reposItem"):
+            return None
+        for i in range(self.reposItem.childCount()):
+            item = self.reposItem.child(i)
+            if isinstance(item, RepoItem) and os.path.normpath(item.repo.path) == os.path.normpath(repo_path):
+                return item
+        return None
+
+    def _repoItemForActiveProject(self):
+        info = self._activeProjectInfo()
+        if info is None:
+            return None
+        return self._repoItemForPath(info[0])
+
+    def _currentRepoItem(self):
+        item = self.tree.currentItem()
+        while item is not None:
+            if isinstance(item, RepoItem):
+                return item
+            item = item.parent()
+        return None
+
+    def _repoItemForProjectSave(self):
+        project = QgsProject.instance()
+        if not project.isDirty():
+            return None
+        repo_item = self._repoItemForActiveProject()
+        if repo_item is not None:
+            return repo_item
+        project_path = project.fileName()
+        if not project_path:
+            return None
+        if not hasattr(self, "reposItem"):
+            return None
+        for i in range(self.reposItem.childCount()):
+            item = self.reposItem.child(i)
+            if isinstance(item, RepoItem) and item.repo.pathInsideRepo(project_path):
+                return item
+        return None
+
+    def _setLoadedProjectMarker(self, repo_path, rel_path):
+        project = QgsProject.instance()
+        repo_key, path_key, hash_key = project_tracking_keys()
+        project.writeEntry(repo_key, "/", repo_path)
+        project.writeEntry(path_key, "/", rel_path)
+        try:
+            blob_hash = Repository(repo_path).blobHash(rel_path)
+            project.writeEntry(hash_key, "/", blob_hash)
+        except Exception:
+            project.writeEntry(hash_key, "/", "")
+
+    def _activeProjectMarker(self):
+        return self._activeProjectInfo()
+
+    def _showTextDialog(self, title, text):
+        dlg = QDialog(iface.mainWindow())
+        dlg.setWindowTitle(title)
+        layout = QVBoxLayout(dlg)
+        edit = QTextEdit()
+        edit.setReadOnly(True)
+        edit.setPlainText(text)
+        edit.setMinimumSize(700, 500)
+        layout.addWidget(edit)
+        buttons = QDialogButtonBox(QDialogButtonBox.StandardButton.Close)
+        buttons.rejected.connect(dlg.reject)
+        layout.addWidget(buttons)
+        dlg.exec()
+
+    def _confirmProjectSave(self, rel_path, diff_text, default_message):
+        dlg = QDialog(iface.mainWindow())
+        dlg.setWindowTitle(tr("Save project to Kart"))
+        layout = QVBoxLayout(dlg)
+        if diff_text:
+            edit = QTextEdit()
+            edit.setReadOnly(True)
+            edit.setPlainText(diff_text)
+            edit.setMinimumSize(700, 400)
+            layout.addWidget(edit)
+        from qgis.PyQt.QtWidgets import QLineEdit
+        msg_edit = QLineEdit(default_message)
+        layout.addWidget(msg_edit)
+        buttons = QDialogButtonBox(
+            QDialogButtonBox.StandardButton.Ok | QDialogButtonBox.StandardButton.Cancel
+        )
+        buttons.accepted.connect(dlg.accept)
+        buttons.rejected.connect(dlg.reject)
+        layout.addWidget(buttons)
+        if dlg.exec() == QDialog.DialogCode.Accepted:
+            return msg_edit.text(), True
+        return "", False
+
+    def _autoPushForRepo(self, repo_item):
+        if not setting(AUTO_PUSH):
+            return
+        try:
+            remotes = repo_item.repo.remotes()
+            if not remotes:
+                return
+            remote = next(iter(remotes))
+            branch = repo_item.repo.currentBranch()
+            repo_item.repo.push(remote, branch)
+        except Exception:
+            pass
 
 
 class RefreshableItem(QTreeWidgetItem):
@@ -299,6 +642,7 @@ class RepoItem(RefreshableItem):
         self.repo = repo
 
         self.populated = False
+        self.filesItem = None
 
         self.setTitle()
         self.setIcon(0, icons.repoIcon)
@@ -332,6 +676,8 @@ class RepoItem(RefreshableItem):
         setSetting(LASTREPO, self.repo.path)
         self.populated = True
         self.datasetsItem.setExpanded(True)
+        self.filesItem = FilesItem(self.repo)
+        self.addChild(self.filesItem)
         self.setTitle()
 
     def actions(self):
@@ -489,12 +835,75 @@ class RepoItem(RefreshableItem):
                         tr("Changes correctly committed"),
                         level=Qgis.MessageLevel.Info,
                     )
+                    self._autoPush()
                 else:
                     iface.messageBar().pushMessage(
                         tr("Commit"),
                         tr("Changes could not be commited"),
                         level=Qgis.MessageLevel.Warning,
                     )
+
+    def _autoPush(self):
+        if not setting(AUTO_PUSH):
+            return
+        try:
+            remotes = self.repo.remotes()
+            if not remotes:
+                return
+            remote = next(iter(remotes))
+            branch = self.repo.currentBranch()
+            self.repo.push(remote, branch)
+        except Exception:
+            pass
+
+    def saveProjectToRepo(self):
+        project = QgsProject.instance()
+        info = self.treeWidget().parent()._activeProjectInfo() if self.treeWidget() and self.treeWidget().parent() else None
+        # Fallback: look up from dock
+        dock = self._getDock()
+        if dock is None:
+            return
+        info = dock._activeProjectInfo()
+        if info is None:
+            return
+        repo_path, rel_path, old_hash = info
+        import tempfile as _tf
+        tmp = _tf.NamedTemporaryFile(suffix=".qgs", delete=False)
+        tmp.close()
+        try:
+            project.write(tmp.name)
+            diff = self.repo.diffFileAgainstPath(rel_path, tmp.name)
+        except Exception:
+            diff = ""
+        finally:
+            pass
+        msg, ok = dock._confirmProjectSave(rel_path, diff, f"Update {rel_path}")
+        if not ok:
+            return
+        try:
+            self.repo.commitFiles(msg, {rel_path: tmp.name})
+            import os as _os
+            _os.unlink(tmp.name)
+            new_hash = self.repo.blobHash(rel_path)
+            dock._setLoadedProjectMarker(self.repo.path, rel_path)
+            dock.updateSaveProjectButton()
+            if hasattr(self, "filesItem") and self.filesItem is not None:
+                self.filesItem.refreshContent()
+            self.setTitle()
+            dock._autoPushForRepo(self)
+        except Exception as e:
+            iface.messageBar().pushMessage(tr("Error"), str(e), level=Qgis.MessageLevel.Warning)
+
+    def _getDock(self):
+        w = self.treeWidget()
+        if w is None:
+            return None
+        p = w.parent()
+        while p is not None:
+            if isinstance(p, KartDockWidget):
+                return p
+            p = p.parent() if hasattr(p, "parent") and callable(p.parent) else None
+        return None
 
     @executeskart
     def showChanges(self):
@@ -859,3 +1268,190 @@ class DatasetItem(QTreeWidgetItem):
             if layer:
                 QgsProject.instance().removeMapLayers([layer.id()])
                 iface.mapCanvas().refresh()
+
+
+class FilesItem(RefreshableItem):
+    def __init__(self, repo):
+        super().__init__()
+        self.repo = repo
+        self.setText(0, tr("Files"))
+        self.setIcon(0, icons.fileIcon if hasattr(icons, "fileIcon") else icons.refreshIcon)
+        self.setChildIndicatorPolicy(QTreeWidgetItem.ChildIndicatorPolicy.ShowIndicator)
+
+    def populate(self):
+        try:
+            status = self.repo.fileStatus()
+        except Exception:
+            return
+        modified = status.get("modified") or []
+        untracked = status.get("untracked") or []
+        deleted = status.get("deleted") or []
+
+        seen = set()
+        for rel_path in modified:
+            self.addChild(RepoFileItem(rel_path, self.repo, "modified"))
+            seen.add(rel_path)
+        for rel_path in untracked:
+            self.addChild(RepoFileItem(rel_path, self.repo, "untracked"))
+            seen.add(rel_path)
+        for rel_path in deleted:
+            self.addChild(RepoFileItem(rel_path, self.repo, "deleted"))
+            seen.add(rel_path)
+
+        try:
+            for rel_path in self.repo.trackedAttachmentFiles():
+                if rel_path not in seen:
+                    self.addChild(RepoFileItem(rel_path, self.repo, "tracked"))
+        except Exception:
+            pass
+
+    def _actions(self):
+        return []
+
+
+class RepoFileItem(QTreeWidgetItem):
+    def __init__(self, rel_path, repo, status="tracked"):
+        super().__init__()
+        self.rel_path = rel_path
+        self.repo = repo
+        self.status = status
+        self.setText(0, rel_path)
+        self._updateIcon()
+
+    def _updateIcon(self):
+        if self.status == "modified":
+            self.setForeground(0, QBrush(QColor(200, 100, 0)))
+        elif self.status == "untracked":
+            self.setForeground(0, QBrush(QColor(0, 150, 0)))
+        elif self.status == "deleted":
+            self.setForeground(0, QBrush(QColor(200, 0, 0)))
+
+    def onDoubleClicked(self):
+        if self.status in ("modified", "untracked"):
+            self._showFileDiff()
+
+    def actions(self):
+        acts = []
+        if self.status == "modified":
+            acts += [
+                (tr("Show working copy diff"), self._showFileDiff, icons.diffIcon if hasattr(icons, "diffIcon") else icons.refreshIcon),
+                (tr("Show last commit diff"), self._showCommitDiff, icons.diffIcon if hasattr(icons, "diffIcon") else icons.refreshIcon),
+                (tr("Commit file"), self._commitFile, icons.commitIcon if hasattr(icons, "commitIcon") else icons.refreshIcon),
+                (tr("Discard changes"), self._discardChanges, icons.refreshIcon),
+            ]
+        elif self.status == "untracked":
+            acts += [
+                (tr("Commit file (add)"), self._commitFile, icons.commitIcon if hasattr(icons, "commitIcon") else icons.refreshIcon),
+            ]
+        elif self.status == "deleted":
+            acts += [
+                (tr("Commit deletion"), self._commitFileDeletion, icons.commitIcon if hasattr(icons, "commitIcon") else icons.refreshIcon),
+                (tr("Restore file"), self._restoreFile, icons.refreshIcon),
+            ]
+        acts += [
+            (tr("Open in Explorer"), self._openInExplorer, icons.refreshIcon),
+        ]
+        return acts
+
+    def _showFileDiff(self):
+        try:
+            diff = self.repo.fileDiff(self.rel_path)
+            if not diff:
+                diff = tr("(no differences)")
+            self._showTextDialog(tr("Working copy diff: {path}").format(path=self.rel_path), diff)
+        except Exception as e:
+            iface.messageBar().pushMessage(tr("Error"), str(e), level=Qgis.MessageLevel.Warning)
+
+    def _showCommitDiff(self):
+        try:
+            diff = self.repo.diffFile(self.rel_path)
+            if not diff:
+                diff = tr("(no differences)")
+            self._showTextDialog(tr("Last commit diff: {path}").format(path=self.rel_path), diff)
+        except Exception as e:
+            iface.messageBar().pushMessage(tr("Error"), str(e), level=Qgis.MessageLevel.Warning)
+
+    def _showTextDialog(self, title, text):
+        dlg = QDialog(iface.mainWindow())
+        dlg.setWindowTitle(title)
+        layout = QVBoxLayout(dlg)
+        edit = QTextEdit()
+        edit.setReadOnly(True)
+        edit.setPlainText(text)
+        edit.setMinimumSize(700, 500)
+        layout.addWidget(edit)
+        buttons = QDialogButtonBox(QDialogButtonBox.StandardButton.Close)
+        buttons.rejected.connect(dlg.reject)
+        layout.addWidget(buttons)
+        dlg.exec()
+
+    def _discardChanges(self):
+        from kart.utils import confirm
+        if confirm(tr("Discard working copy changes to '{path}'?").format(path=self.rel_path)):
+            try:
+                self.repo.restoreFile(self.rel_path)
+                self._refreshAfterFileAction()
+            except Exception as e:
+                iface.messageBar().pushMessage(tr("Error"), str(e), level=Qgis.MessageLevel.Warning)
+
+    def _restoreFile(self):
+        from kart.utils import confirm
+        if confirm(tr("Restore deleted file '{path}'?").format(path=self.rel_path)):
+            try:
+                self.repo.restoreFile(self.rel_path)
+                self._refreshAfterFileAction()
+            except Exception as e:
+                iface.messageBar().pushMessage(tr("Error"), str(e), level=Qgis.MessageLevel.Warning)
+
+    def _commitFile(self):
+        msg, ok = QInputDialog.getText(
+            iface.mainWindow(),
+            tr("Commit message"),
+            tr("Enter a commit message for '{path}':").format(path=self.rel_path),
+        )
+        if ok and msg:
+            try:
+                self.repo.commitFiles(msg, [self.rel_path])
+                self._autoPush()
+                self._refreshAfterFileAction()
+            except Exception as e:
+                iface.messageBar().pushMessage(tr("Error"), str(e), level=Qgis.MessageLevel.Warning)
+
+    def _commitFileDeletion(self):
+        msg, ok = QInputDialog.getText(
+            iface.mainWindow(),
+            tr("Commit message"),
+            tr("Enter a commit message for deleting '{path}':").format(path=self.rel_path),
+        )
+        if ok and msg:
+            try:
+                self.repo.commitFiles(msg, [self.rel_path])
+                self._autoPush()
+                self._refreshAfterFileAction()
+            except Exception as e:
+                iface.messageBar().pushMessage(tr("Error"), str(e), level=Qgis.MessageLevel.Warning)
+
+    def _autoPush(self):
+        if not setting(AUTO_PUSH):
+            return
+        try:
+            remotes = self.repo.remotes()
+            if not remotes:
+                return
+            remote = next(iter(remotes))
+            branch = self.repo.currentBranch()
+            self.repo.push(remote, branch)
+        except Exception:
+            pass
+
+    def _openInExplorer(self):
+        full_path = os.path.join(self.repo.path, self.rel_path.replace("/", os.sep))
+        folder = os.path.dirname(full_path)
+        if os.path.exists(folder):
+            import subprocess as _sp
+            _sp.Popen(["explorer", folder])
+
+    def _refreshAfterFileAction(self):
+        files_item = self.parent()
+        if files_item is not None:
+            files_item.refreshContent()

--- a/kart/gui/settingsdialog.py
+++ b/kart/gui/settingsdialog.py
@@ -7,12 +7,16 @@ from qgis.utils import iface
 
 from kart.utils import (
     AUTOCOMMIT,
+    AUTO_COMMIT_ON_SAVE,
+    AUTO_PUSH,
     DIFFSTYLES,
     HELPERMODE,
     KARTPATH,
     setSetting,
     setting,
     tr,
+    WARN_ON_EXIT_UNCOMMITTED,
+    WARN_ON_EXIT_UNPUSHED,
 )
 
 WIDGET, BASE = uic.loadUiType(os.path.join(os.path.dirname(__file__), "settingsdialog.ui"))
@@ -44,6 +48,10 @@ class SettingsDialog(BASE, WIDGET):
         self.comboDiffStyles.setCurrentText(setting(DIFFSTYLES))
         self.chkHelperMode.setChecked(setting(HELPERMODE))
         self.chkAutoCommit.setChecked(setting(AUTOCOMMIT))
+        self.chkAutoCommitOnSave.setChecked(setting(AUTO_COMMIT_ON_SAVE))
+        self.chkAutoPush.setChecked(setting(AUTO_PUSH))
+        self.chkWarnOnExitUncommitted.setChecked(setting(WARN_ON_EXIT_UNCOMMITTED))
+        self.chkWarnOnExitUnpushed.setChecked(setting(WARN_ON_EXIT_UNPUSHED))
         self.txtKartPath.setText(setting(KARTPATH))
 
     def browse(self, textbox):
@@ -55,6 +63,10 @@ class SettingsDialog(BASE, WIDGET):
         setSetting(KARTPATH, self.txtKartPath.text())
         setSetting(HELPERMODE, self.chkHelperMode.isChecked())
         setSetting(AUTOCOMMIT, self.chkAutoCommit.isChecked())
+        setSetting(AUTO_COMMIT_ON_SAVE, self.chkAutoCommitOnSave.isChecked())
+        setSetting(AUTO_PUSH, self.chkAutoPush.isChecked())
+        setSetting(WARN_ON_EXIT_UNCOMMITTED, self.chkWarnOnExitUncommitted.isChecked())
+        setSetting(WARN_ON_EXIT_UNPUSHED, self.chkWarnOnExitUnpushed.isChecked())
         setSetting(DIFFSTYLES, self.comboDiffStyles.currentText())
         self.accept()
 
@@ -76,6 +88,13 @@ class SettingsDialog(BASE, WIDGET):
         # Auto Commit Section
         self.groupBox_3.setTitle(tr("Auto commit"))
         self.chkAutoCommit.setText(tr("Commit automatically after closing editing"))
+        self.chkAutoCommitOnSave.setText(tr("Prompt to commit when saving QGIS project"))
+
+        # Synchronisation Section
+        self.groupBoxSync.setTitle(tr("Synchronisation"))
+        self.chkAutoPush.setText(tr("Automatically push after each commit"))
+        self.chkWarnOnExitUncommitted.setText(tr("Warn on exit if there are uncommitted changes"))
+        self.chkWarnOnExitUnpushed.setText(tr("Warn on exit if there are unpushed commits"))
 
         # Diff Styles Section
         self.groupBox_2.setTitle(tr("Diff styles"))

--- a/kart/gui/settingsdialog.ui
+++ b/kart/gui/settingsdialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>522</width>
-    <height>300</height>
+    <height>420</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -66,6 +66,43 @@
        <widget class="QCheckBox" name="chkAutoCommit">
         <property name="text">
          <string>Commit automatically after closing editing</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="chkAutoCommitOnSave">
+        <property name="text">
+         <string>Prompt to commit when saving QGIS project</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QGroupBox" name="groupBoxSync">
+     <property name="title">
+      <string>Synchronisation</string>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayoutSync">
+      <item>
+       <widget class="QCheckBox" name="chkAutoPush">
+        <property name="text">
+         <string>Automatically push after each commit</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="chkWarnOnExitUncommitted">
+        <property name="text">
+         <string>Warn on exit if there are uncommitted changes</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="chkWarnOnExitUnpushed">
+        <property name="text">
+         <string>Warn on exit if there are unpushed commits</string>
         </property>
        </widget>
       </item>

--- a/kart/kartapi.py
+++ b/kart/kartapi.py
@@ -1,3 +1,4 @@
+import difflib
 import json
 import locale
 import os
@@ -31,6 +32,11 @@ from kart import logging
 from kart.gui.installationwarningdialog import InstallationWarningDialog
 from kart.gui.userconfigdialog import UserConfigDialog
 from kart.utils import HELPERMODE, KARTPATH, setSetting, setting, tr
+
+# Suppress console windows on Windows for all subprocess calls.
+_POPEN_FLAGS = (
+    {"creationflags": subprocess.CREATE_NO_WINDOW} if os.name == "nt" else {}
+)
 
 MINIMUM_SUPPORTED_VERSION = "0.14.0"
 CURRENT_VERSION = "0.17.0"
@@ -213,6 +219,10 @@ def executeKart(commands, path=None, jsonoutput=False, feedback=None):
             executeKart.env.pop("PYTHONHOME")
         if "GDAL_DRIVER_PATH" in executeKart.env:
             executeKart.env.pop("GDAL_DRIVER_PATH")
+        # PYTHONPATH from QGIS causes kart's `import logging` to find the
+        # plugin's kart/logging.py instead of the stdlib module.
+        if "PYTHONPATH" in executeKart.env:
+            executeKart.env.pop("PYTHONPATH")
 
     # always set the use helper env var as it is long lived and the setting may have changed
     executeKart.env["KART_USE_HELPER"] = "1" if setting(HELPERMODE) else ""
@@ -239,6 +249,7 @@ def executeKart(commands, path=None, jsonoutput=False, feedback=None):
             universal_newlines=True,
             encoding=encoding,
             cwd=path,
+            **_POPEN_FLAGS,
         ) as proc:
             if feedback is not None:
                 output = []
@@ -267,6 +278,41 @@ def executeKart(commands, path=None, jsonoutput=False, feedback=None):
         QApplication.restoreOverrideCursor()
 
 
+def executeKartBinary(commands, path=None):
+    """Like executeKart but returns raw bytes (for blob content)."""
+    commands.insert(0, kartExecutable())
+
+    if not hasattr(executeKart, "env"):
+        executeKart.env = os.environ.copy()
+        if "PYTHONHOME" in executeKart.env:
+            executeKart.env.pop("PYTHONHOME")
+        if "GDAL_DRIVER_PATH" in executeKart.env:
+            executeKart.env.pop("GDAL_DRIVER_PATH")
+        if "PYTHONPATH" in executeKart.env:
+            executeKart.env.pop("PYTHONPATH")
+        executeKart.env["KART_USE_HELPER"] = "1" if setting(HELPERMODE) else ""
+        executeKart.env["KART_POINT_CLOUD_VPCS"] = "1"
+        executeKart.env["KART_RASTER_VRTS"] = "1"
+
+    try:
+        with subprocess.Popen(
+            commands,
+            shell=os.name == "nt",
+            env=executeKart.env,
+            stdout=subprocess.PIPE,
+            stdin=subprocess.DEVNULL,
+            stderr=subprocess.PIPE,
+            cwd=path,
+            **_POPEN_FLAGS,
+        ) as proc:
+            stdout, stderr = proc.communicate()
+            if proc.returncode:
+                raise KartException(stderr.decode("utf-8", "replace"))
+            return stdout
+    except Exception as e:
+        raise KartException(str(e))
+
+
 class Repository:
     def __init__(self, path):
         self.path = path
@@ -275,6 +321,9 @@ class Repository:
 
     def executeKart(self, commands, jsonoutput=False):
         return executeKart(commands, self.path, jsonoutput)
+
+    def executeKartBinary(self, commands):
+        return executeKartBinary(commands, self.path)
 
     @staticmethod
     def supportedDbTypes():
@@ -770,3 +819,164 @@ class Repository:
         for layer in QgsProject.instance().mapLayers().values():
             if self.layerBelongsToRepo(layer):
                 layer.triggerRepaint()
+
+    def pathInsideRepo(self, path):
+        repo_root = os.path.abspath(self.path)
+        candidate = os.path.abspath(path)
+        try:
+            return os.path.commonpath([repo_root, candidate]) == repo_root
+        except ValueError:
+            return False
+
+    def repoRelativePath(self, path):
+        return os.path.relpath(
+            os.path.abspath(path), os.path.abspath(self.path)
+        ).replace(os.path.sep, "/")
+
+    def validRepoRelativePath(self, rel_path):
+        if not rel_path or os.path.isabs(rel_path):
+            return False
+        normalized = os.path.normpath(rel_path).replace(os.path.sep, "/")
+        return normalized == rel_path and not normalized.startswith("../") and normalized != ".."
+
+    def trackedAttachmentFiles(self, ref="HEAD"):
+        """Return all tracked attachment files at *ref* via ``kart ls-files``."""
+        out = self.executeKart(["ls-files", ref])
+        return [line.strip() for line in out.splitlines() if line.strip()]
+
+    def aheadBehind(self):
+        """Return (ahead, behind) counts via ``kart ahead-behind``. Returns (0, 0) on failure."""
+        try:
+            out = self.executeKart(["ahead-behind"]).strip()
+            parts = out.split()
+            if len(parts) == 2:
+                return int(parts[0]), int(parts[1])
+        except Exception:
+            pass
+        return 0, 0
+
+    def fileStatus(self):
+        """Return ``{"modified": [...], "untracked": [...], "deleted": [...]}`` for attachment files."""
+        ret = self.executeKart(["status", "-ojson"])
+        data = json.loads(ret)
+        status = list(data.values())[0]
+        files = (status.get("workingCopy") or {}).get("files")
+        if files is None:
+            return {"modified": [], "untracked": [], "deleted": []}
+        return files
+
+    def restoreFile(self, rel_path):
+        """Restore *rel_path* in the working directory to its HEAD state."""
+        self.executeKart(["restore", "-s", "HEAD", "--", rel_path])
+
+    def readFileFromRepo(self, rel_path, ref="HEAD"):
+        if not self.validRepoRelativePath(rel_path):
+            raise KartException("Invalid repository-relative path")
+        return self.executeKartBinary(["show-file", f"{ref}:{rel_path}"])
+
+    def showFileAtRef(self, rel_path, ref="HEAD"):
+        return self.readFileFromRepo(rel_path, ref)
+
+    def blobHash(self, rel_path, ref="HEAD"):
+        if not self.validRepoRelativePath(rel_path):
+            raise KartException("Invalid repository-relative path")
+        return self.executeKart(["blob-hash", f"{ref}:{rel_path}"]).strip()
+
+    def fileDiff(self, rel_path):
+        """Return a unified diff string comparing ``HEAD:<rel_path>`` to the working-directory file."""
+        try:
+            old_bytes = self.readFileFromRepo(rel_path)
+            old_text = old_bytes.decode("utf-8", "replace")
+            old_label = f"HEAD:{rel_path}"
+        except Exception:
+            old_text = ""
+            old_label = f"HEAD:{rel_path} (new file)"
+
+        full_path = os.path.join(self.path, rel_path.replace("/", os.sep))
+        try:
+            with open(full_path, encoding="utf-8", errors="replace") as f:
+                new_text = f.read()
+        except Exception:
+            new_text = ""
+
+        old_lines = old_text.splitlines(keepends=True)
+        new_lines = new_text.splitlines(keepends=True)
+        return "".join(
+            difflib.unified_diff(
+                old_lines,
+                new_lines,
+                fromfile=old_label,
+                tofile=f"working copy:{rel_path}",
+                lineterm="\n",
+            )
+        )
+
+    def diffFile(self, rel_path, refa="HEAD~1", refb="HEAD"):
+        if not self.validRepoRelativePath(rel_path):
+            raise KartException("Invalid repository-relative path")
+        try:
+            old_bytes = self.readFileFromRepo(rel_path, refa)
+            old_text = old_bytes.decode("utf-8", "replace")
+        except KartException:
+            old_text = ""
+        try:
+            new_bytes = self.readFileFromRepo(rel_path, refb)
+            new_text = new_bytes.decode("utf-8", "replace")
+        except KartException:
+            new_text = ""
+        return "".join(
+            difflib.unified_diff(
+                old_text.splitlines(keepends=True),
+                new_text.splitlines(keepends=True),
+                fromfile=f"{refa}:{rel_path}",
+                tofile=f"{refb}:{rel_path}",
+                lineterm="\n",
+            )
+        )
+
+    def diffFileAgainstPath(self, rel_path, source_path, ref="HEAD"):
+        """Return a unified text diff between a repository blob and a file.
+
+        Used for QGIS project saves: the candidate .qgs is written to a temporary
+        file, the user reviews this diff before the file is committed.
+        """
+        if not self.validRepoRelativePath(rel_path):
+            raise KartException("Invalid repository-relative path")
+
+        try:
+            old_bytes = self.showFileAtRef(rel_path, ref)
+            old_text = old_bytes.decode("utf-8", "replace")
+            old_label = f"{ref}:{rel_path}"
+        except KartException:
+            old_text = ""
+            old_label = f"{ref}:{rel_path} (new file)"
+
+        with open(source_path, "rb") as f:
+            new_text = f.read().decode("utf-8", "replace")
+
+        return "".join(
+            difflib.unified_diff(
+                old_text.splitlines(keepends=True),
+                new_text.splitlines(keepends=True),
+                fromfile=old_label,
+                tofile=f"working copy:{rel_path}",
+                lineterm="\n",
+            )
+        )
+
+    def commitFiles(self, message, files):
+        """Commit attachment files via ``kart commit-files``.
+
+        *files* is either a list of repo-relative paths (already in working copy)
+        or a dict mapping repo-relative paths to source filesystem paths.
+        """
+        if not self.checkUserConfigured():
+            return False
+        cmd = ["commit-files", "-m", message]
+        if isinstance(files, dict):
+            for rel_path, src_path in files.items():
+                cmd += [f"{rel_path}={src_path}"]
+        else:
+            cmd += list(files)
+        self.executeKart(cmd)
+        return True

--- a/kart/utils.py
+++ b/kart/utils.py
@@ -96,8 +96,19 @@ HELPERMODE = "HelperMode"
 AUTOCOMMIT = "AutoCommit"
 DIFFSTYLES = "DiffStyles"
 LASTREPO = "LastRepo"
+WARN_ON_EXIT_UNCOMMITTED = "WarnOnExitUncommitted"
+WARN_ON_EXIT_UNPUSHED = "WarnOnExitUnpushed"
+AUTO_PUSH = "AutoPush"
+AUTO_COMMIT_ON_SAVE = "AutoCommitOnSave"
 
-setting_types = {HELPERMODE: bool, AUTOCOMMIT: bool}
+setting_types = {
+    HELPERMODE: bool,
+    AUTOCOMMIT: bool,
+    WARN_ON_EXIT_UNCOMMITTED: bool,
+    WARN_ON_EXIT_UNPUSHED: bool,
+    AUTO_PUSH: bool,
+    AUTO_COMMIT_ON_SAVE: bool,
+}
 
 
 def setSetting(name, value):


### PR DESCRIPTION
﻿## Summary

This PR adds attachment file visibility, QGIS project tracking inside Kart repositories, and sync quality-of-life improvements to the plugin.

**Depends on:** koordinates/kart#1101 (adds `blob-hash`, `show-file`, `ahead-behind`, `ls-files` plumbing commands)

## Changes

### `kartapi.py` — new plumbing wrappers

**Subprocess fixes**
- Add `CREATE_NO_WINDOW` flag on Windows to prevent kart from opening a console window
- Clear `PYTHONPATH` before invoking kart — QGIS sets `PYTHONPATH` to include the plugin directory, which caused kart's `import logging` to resolve to `kart/logging.py` instead of the stdlib

**New `Repository` methods**
- `executeKartBinary(commands)` — like `executeKart` but returns raw `bytes` instead of a decoded string; needed for `show-file` whose output is arbitrary binary blob content (e.g. `.qgz` files)
- `trackedAttachmentFiles(ref)` — list tracked attachment files at a ref via `kart ls-files`
- `aheadBehind()` — return `(ahead, behind)` commit counts via `kart ahead-behind`
- `fileStatus()` — return `{modified, untracked, deleted}` file lists via `kart status -ojson`
- `restoreFile(rel_path)` — restore a working-copy file to HEAD via `kart restore`
- `readFileFromRepo(rel_path, ref)` — read file content as bytes via `kart show-file`
- `blobHash(rel_path, ref)` — get blob OID via `kart blob-hash`
- `fileDiff(rel_path)` — unified diff between the working copy and HEAD
- `diffFile(rel_path, refa, refb)` — unified diff between two refs
- `diffFileAgainstPath(rel_path, source_path)` — diff between a repo blob and a local file (used for project-save review)
- `pathInsideRepo()`, `repoRelativePath()`, `validRepoRelativePath()` — path utility helpers

### `dockwidget.py` — attachment file tree + QGIS project tracking

**Attachment file tree**
- New `FilesItem` tree node under each repository showing all tracked attachment files
- New `RepoFileItem` with context-sensitive per-file actions depending on status (modified / untracked / deleted / clean)

**QGIS project tracking in Kart**
- Auto-detect `.qgs` / `.qgz` files opened from a Kart working copy
- Store tracking markers (`repo_path`, `rel_path`, `blob_hash`) as QGIS project properties; clear them when the project is closed
- Bold the currently open project file in the Files tree
- "Save project to Kart" button in the dock panel; enabled when the tracked project has unsaved changes
- Diff preview before committing: shows a unified diff of `.qgs` changes so the user can review before saving to Kart
- Auto-prompt on Ctrl+S / File > Save Project when the project is tracked (configurable via new setting)
- Ahead/behind indicator in the repo title: `[branch +2/-1]` when commits are ahead or behind the remote

### `utils.py` — new settings constants

Add `AUTO_PUSH`, `AUTO_COMMIT_ON_SAVE`, `WARN_ON_EXIT_UNCOMMITTED`, `WARN_ON_EXIT_UNPUSHED` with corresponding entries in `setting_types`.

### `settingsdialog.ui` / `settingsdialog.py` — new settings UI

- New **Auto commit** checkbox: "Prompt to commit when saving QGIS project"
- New **Synchronisation** group: "Automatically push after each commit", "Warn on exit if there are uncommitted changes", "Warn on exit if there are unpushed commits"