### PR TITLE
Fix history date filter using UTC instead of local time

### DIFF
--- a/kart/gui/historyviewer.py
+++ b/kart/gui/historyviewer.py
@@ -59,6 +59,18 @@ COLORS = [
 ]
 
 
+def commitDate(authorTime):
+    """Local-time date of a commit, used for history date filtering.
+
+    Kart records ``authorTime`` in UTC (e.g. ``2021-11-16T08:57:57Z``). The
+    date filter compares against the local-time date pickers, so the commit
+    time must be converted to local time before extracting the date,
+    otherwise commits near a UTC day boundary are filtered onto the wrong
+    day (issue #87).
+    """
+    return QDateTime.fromString(authorTime, Qt.DateFormat.ISODate).toLocalTime().date()
+
+
 class HistoryTree(QTreeWidget):
     def __init__(self, repo, dataset, parent):
         super(HistoryTree, self).__init__()
@@ -441,9 +453,7 @@ class HistoryTree(QTreeWidget):
                 hide = bool(self.filterText) and not any(
                     self.filterText in t.lower() for t in values
                 )
-                date = QDateTime.fromString(
-                    item.commit["authorTime"], Qt.DateFormat.ISODate
-                ).date()
+                date = commitDate(item.commit["authorTime"])
                 withinDates = date >= self.startDate and date <= self.endDate
                 hide = hide or not withinDates
                 item.setHidden(hide)

--- a/kart/tests/test_historyviewer.py
+++ b/kart/tests/test_historyviewer.py
@@ -1,0 +1,38 @@
+import os
+import time
+
+from qgis.PyQt.QtCore import QDate
+from qgis.testing import start_app, unittest
+
+start_app()
+
+from kart.gui.historyviewer import commitDate  # noqa: E402
+
+
+class CommitDateTest(unittest.TestCase):
+    """Regression tests for history date filtering (issue #87).
+
+    Kart records commit times in UTC; the date filter must compare against
+    the viewer's local date so commits near a UTC day boundary aren't hidden.
+    """
+
+    def setUp(self):
+        # Pin to UTC-6 (the timezone reported in issue #87).
+        self._tz = os.environ.get("TZ")
+        os.environ["TZ"] = "America/Chicago"
+        time.tzset()
+
+    def tearDown(self):
+        if self._tz is None:
+            os.environ.pop("TZ", None)
+        else:
+            os.environ["TZ"] = self._tz
+        time.tzset()
+
+    def test_commit_date_uses_local_time(self):
+        # 02:16 UTC on the 8th is 20:16 on the 7th in UTC-6.
+        self.assertEqual(commitDate("2022-11-08T02:16:11Z"), QDate(2022, 11, 7))
+
+    def test_commit_date_same_day(self):
+        # Daytime UTC stays on the same local day.
+        self.assertEqual(commitDate("2021-11-16T08:57:57Z"), QDate(2021, 11, 16))

--- a/kart/tests/test_historyviewer.py
+++ b/kart/tests/test_historyviewer.py
@@ -9,6 +9,7 @@ start_app()
 from kart.gui.historyviewer import commitDate  # noqa: E402
 
 
+@unittest.skipUnless(hasattr(time, "tzset"), "requires time.tzset() (not available on Windows)")
 class CommitDateTest(unittest.TestCase):
     """Regression tests for history date filtering (issue #87).
 


### PR DESCRIPTION
Closes #87.

Kart records commit times in UTC, but the history date pickers use local machine time. `filterCommits` took `.date()` straight from the UTC-parsed `authorTime`, so commits near a UTC day boundary were filtered onto the wrong calendar day and could be hidden (reported by a UTC-6 user).

Converts the commit time to local time before extracting the date.

### screenshot (local TZ = UTC+12):
<img width="934" height="281" alt="Screenshot 2026-06-04 at 10 39 16 PM" src="https://github.com/user-attachments/assets/ac3c1cbc-4d31-4859-88ca-b3a1c8150bee" />
