### PR TITLE
Avoid shell=True in subprocess calls; add request timeout

### DIFF
--- a/kart/gui/installationwarningdialog.py
+++ b/kart/gui/installationwarningdialog.py
@@ -45,14 +45,17 @@ class DownloadAndInstallThread(QThread):
                     os.getenv("SystemRoot"),
                     r"system32\WindowsPowerShell\v1.0\powershell.exe",
                 )
-                command = (
-                    rf"""{powershell} -Command "& {{ Start-Process 'msiexec' """
-                    rf"""-ArgumentList @('/a', '{msipath}', '/qb', """
-                    r"""'TARGETDIR=\"%ProgramFiles%\"')"""
-                    rf""" -Verb RunAs -Wait}}" """
-                )
+                program_files = os.getenv("ProgramFiles", r"C:\Program Files")
+                command = [
+                    powershell,
+                    "-Command",
+                    "& { Start-Process 'msiexec' "
+                    f"-ArgumentList @('/a', '{msipath}', '/qb', "
+                    rf"""'TARGETDIR=\"{program_files}\"')"""
+                    " -Verb RunAs -Wait}",
+                ]
                 if msipath is not None:
-                    subprocess.call(command, shell=True)
+                    subprocess.call(command)
                     shutil.rmtree(os.path.dirname(msipath))
             elif sys.platform == "darwin":
                 arch = subprocess.check_output(["arch"], text=True).strip()
@@ -69,9 +72,8 @@ class DownloadAndInstallThread(QThread):
 
                 filename = MACOS_FILE.format(version=self.version, arch=arch)
                 pkgpath = self._download(url, filename)
-                command = f"open -W {pkgpath}"
                 if pkgpath is not None:
-                    subprocess.call(command, shell=True)
+                    subprocess.call(["open", "-W", pkgpath])
                     shutil.rmtree(os.path.dirname(pkgpath))
             else:
                 url = RELEASE_URL.format(version=self.version)
@@ -87,7 +89,7 @@ class DownloadAndInstallThread(QThread):
         dirname = tempfile.mkdtemp()
         downloadpath = os.path.join(dirname, filename)
         chunk_size = 1024
-        r = requests.get(fullurl, stream=True)
+        r = requests.get(fullurl, stream=True, timeout=30)
         file_size = r.headers.get("content-length") or 0
         file_size = int(file_size)
         percentage_per_chunk = 100.0 / (file_size / chunk_size)

--- a/kart/kartapi.py
+++ b/kart/kartapi.py
@@ -231,7 +231,6 @@ def executeKart(commands, path=None, jsonoutput=False, feedback=None):
         #  ways in which this can deadlock
         with subprocess.Popen(
             commands,
-            shell=os.name == "nt",
             env=executeKart.env,
             stdout=subprocess.PIPE,
             stdin=subprocess.DEVNULL,


### PR DESCRIPTION
## What

The QGIS plugin registry blocked the v1.1.0 release for "critical security issues" — its static checker flags `shell=True` in subprocess calls and `requests.get` without a timeout.

- `kartapi.py`: drop `shell=os.name == "nt"` from `executeKart`. `commands[0]` is always a full path to `kart.exe`, so the shell was never needed.
- `installationwarningdialog.py`: pass argument lists instead of shell strings for the Windows MSI install and macOS pkg open. `%ProgramFiles%` is now expanded in Python (cmd.exe did this previously).
- `installationwarningdialog.py`: add `timeout=30` to the Kart download request.

These are not exploitable in practice (no untrusted input reaches the shell strings), but the registry's checker rejects the patterns regardless. No behaviour change on the happy path.

## Risks involved

- [x] No notable risks

## Performance implications

No.

## Deployment/migration

n/a