### PR TITLE
Fix: Qt6 compatibility for QgsMapMouseEvent

### DIFF
--- a/kart/gui/mapswipetool.py
+++ b/kart/gui/mapswipetool.py
@@ -55,7 +55,7 @@ class MapSwipeTool(QgsMapTool):
         self.canvas().setCursor(QCursor(Qt.CursorShape.PointingHandCursor))
 
     def canvasMoveEvent(self, e):
-        if (e.x(), e.y()) == (self.firstPoint.x(), self.firstPoint.y()):
+        if e.pos() == self.firstPoint:
             # the moveEvent was fired immediately after the press event,
             # don't change the swipe direction
             return


### PR DESCRIPTION
### Problem

The swipe direction changes introduced in #62 use e.x() and e.y() in canvasMoveEvent. These methods are not available in Qt6/QGIS 4, resulting in:

AttributeError: 'QgsMapMouseEvent' object has no attribute 'x'

### Solution

Replace the position comparison with a Qt5/Qt6-compatible approach using e.pos().

### Tested on
QGIS 4.0.3-Norrköping (Qt6.10 / Python 3.13)
QGIS 3.40.15-Bratislava (Qt5.15 / Python 3.14)