### PR TITLE
Windows: decode Kart output tolerantly (#137)

### DIFF
--- a/kart/kartapi.py
+++ b/kart/kartapi.py
@@ -1,5 +1,4 @@
 import json
-import locale
 import os
 import re
 import subprocess
@@ -223,7 +222,6 @@ def executeKart(commands, path=None, jsonoutput=False, feedback=None):
     executeKart.env["KART_RASTER_VRTS"] = "1"
 
     try:
-        encoding = locale.getpreferredencoding(False)
         QApplication.setOverrideCursor(Qt.CursorShape.WaitCursor)
         logging.debug(f"Command: {' '.join(commands)}")
         # TODO - all of this should be replaced by useage of QgsTask which
@@ -236,7 +234,15 @@ def executeKart(commands, path=None, jsonoutput=False, feedback=None):
             stdin=subprocess.DEVNULL,
             stderr=subprocess.PIPE,
             universal_newlines=True,
-            encoding=encoding,
+            # Decode as utf-8 rather than the locale codepage: Kart's JSON
+            # output is utf-8 (msgspec writes raw utf-8 bytes), so on a Windows
+            # cp1252 locale the old code silently corrupted non-ASCII data. Its
+            # human banner/progress text can still contain a stray codepage byte
+            # (e.g. a '»' = 0xbb), which is invalid utf-8 and previously crashed
+            # the reader thread under QGIS 4 / Python utf-8 mode (issue #137);
+            # errors="replace" tolerates those rare cosmetic bytes.
+            encoding="utf-8",
+            errors="replace",
             cwd=path,
         ) as proc:
             if feedback is not None:

--- a/kart/tests/test_kartapi.py
+++ b/kart/tests/test_kartapi.py
@@ -80,6 +80,48 @@ class TestKartapi(unittest.TestCase):
         version = installedVersion()
         assert re.match(r"\d+\.\d+\.\d+", version)
 
+    def testDecodesNonUtf8Output(self):
+        """
+        Kart's --version banner contains a '»' (0xbb) encoded in the Windows
+        ANSI codepage. Under QGIS 4 / Python UTF-8 mode the preferred encoding
+        is utf-8, where 0xbb is invalid and previously crashed the subprocess
+        reader thread, returning empty output (issue #137). Output must decode
+        without raising.
+        """
+        with tempfile.TemporaryDirectory() as folder:
+            fakeKart = os.path.join(folder, "kart")
+            with open(fakeKart, "w") as f:
+                f.write(
+                    "#!/usr/bin/env python3\n"
+                    "import sys\n"
+                    r"sys.stdout.buffer.write(b'Kart v1.2.3\n\xbb GDAL v3.8.5\n')"
+                    "\n"
+                )
+            os.chmod(fakeKart, 0o755)
+            setSetting(KARTPATH, folder)
+            output = executeKart(["--version"])
+            assert output.startswith("Kart v1.2.3")
+
+    def testDecodesUtf8JsonData(self):
+        """
+        Kart's JSON output is utf-8 (msgspec writes raw utf-8 bytes), so
+        non-ASCII data must be decoded as utf-8 and not the locale codepage,
+        which would silently corrupt it (e.g. on a Windows cp1252 locale).
+        """
+        with tempfile.TemporaryDirectory() as folder:
+            fakeKart = os.path.join(folder, "kart")
+            with open(fakeKart, "w", encoding="utf-8") as f:
+                f.write(
+                    "#!/usr/bin/env python3\n"
+                    "import sys\n"
+                    'sys.stdout.buffer.write(\'{"name": "caf\\u00e9"}\''
+                    ".encode('utf-8'))\n"
+                )
+            os.chmod(fakeKart, 0o755)
+            setSetting(KARTPATH, folder)
+            output = executeKart(["data"], jsonoutput=True)
+            assert output == {"name": "café"}
+
     def testStoreReposInSettings(self):
         manager = RepoManager()
         assert not manager.repos()

--- a/kart/tests/test_kartapi.py
+++ b/kart/tests/test_kartapi.py
@@ -114,7 +114,7 @@ class TestKartapi(unittest.TestCase):
                 f.write(
                     "#!/usr/bin/env python3\n"
                     "import sys\n"
-                    'sys.stdout.buffer.write(\'{"name": "caf\\u00e9"}\''
+                    'sys.stdout.buffer.write(\'{"name": "café"}\''
                     ".encode('utf-8'))\n"
                 )
             os.chmod(fakeKart, 0o755)


### PR DESCRIPTION
## What

Fixes #137 — on Windows with QGIS 4.0.3 the plugin reports Kart as not installed ("Command output: None").

## Why

QGIS 4 runs Python in UTF-8 mode, so `locale.getpreferredencoding(False)` returns `utf-8` (QGIS 3 / Qt5 returned `cp1252`). Kart's `--version` banner emits a `»` bullet as the Windows ANSI codepage byte `0xbb`, which is invalid UTF-8. Decoding it crashed the subprocess reader thread, leaving stdout empty, so `installedVersion()` saw no `"Kart v"` and concluded Kart wasn't installed.

Confirmed on a real Windows + QGIS 4.0.3 + Kart install:
```
raw bytes: b'...Contributors\r\n\xbb GDAL v3.8.5...'
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xbb in position 50
```

## How

Decode Kart's output explicitly as **utf-8** (with `errors="replace"`) instead of the locale codepage.

- Kart's JSON output is utf-8 — the diff/show writers use `msgspec`, which writes **raw utf-8 bytes** and does not escape non-ASCII. So decoding with the locale codepage also **silently corrupted** non-ASCII data (feature values, commit messages, dataset names) on a Windows cp1252 locale. Decoding as utf-8 fixes that latent bug too.
- `errors="replace"` tolerates the rare non-utf-8 byte in cosmetic human text (the `»` banner, progress lines), so those never crash the reader thread.

## Risks

No notable risks. Decoding is now utf-8 (correct for Kart's JSON data) and tolerant of stray bytes rather than crashing.

## Performance / migration

n/a